### PR TITLE
Address design feedback for search bar/dropdown CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
     <link rel="stylesheet" href="src/css/table.css">
     <link rel="stylesheet" href="src/css/search.css">
     <link rel="stylesheet" href="src/css/visualization.css">
-    <link rel="stylesheet" href="src/css/search.css">
     <link rel="stylesheet" href="src/css/mobile.css">
   </head>
   <body>
@@ -168,7 +167,8 @@
             transition: undefined,
             duration: 0,
             variation: false
-          }
+          },
+          duration: 0
         });
       });
     </script>

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -3,12 +3,17 @@
   display: flex;
 }
 
-.ui.fluid.dropdown, .ui.fluid.dropdown:hover {
+.ui.fluid.dropdown {
   width: auto;
   min-height: unset;
   flex-grow: 1;
   background-color: #000;
-  border: 1px #222 solid;
+  border: 0.5px #333 transparent;
+}
+
+.ui.fluid.dropdown:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+  transition: 0.2s, ease;
 }
 
 .ui.fluid.dropdown > .dropdown.icon {
@@ -26,6 +31,7 @@
   vertical-align: middle;
   padding-left: 0.5em;
   padding-right: 0.5em;
+  border-radius: 10px;
 }
 
 i.icon.delete {
@@ -46,27 +52,29 @@ i.icon.delete:hover {
 
 /* Dropdown */
 .ui.selection.active.dropdown {
-  border-color: #222;
+  border-color: rgba(255, 255, 255, 0.4);
 }
 
 .ui.selection.active.dropdown:hover {
-  border-color: #5c5c5c;
+  border-color: rgba(255, 255, 255, 0.4);
 }
 
 .ui.selection.active.dropdown .menu {
+  min-width: 100%;
+  width: 100%;
   background-color: #000;
   border-radius: 0;
-  border-color: #222;
+  border-color: rgba(255, 255, 255, 0.4);
 }
 
 .ui.selection.active.dropdown:hover .menu {
-  border-color: #5c5c5c;
+  border-color:rgba(255, 255, 255, 0.4);
 }
 
 .ui.selection.dropdown .menu > .item {
   border-top: 0;
   color: #fff;
-  font-size: 11px;
+  font-size: 13px;
 }
 
 .ui.dropdown.selected, .ui.dropdown .menu .selected.item {


### PR DESCRIPTION
- Change placeholder text and county options from dropdown to 13px
- Border
  - New edit: change background color to #333
  - Set border to 0.5px, transparent
  - When hovering over the search bar, border color changes to rgba(255, 255, 255, 0.4), transition: 0.2s, ease;
  - When focused, border remains at rgba(255, 255, 255, 0.4)
- Currently the dropdown is showing a stretching behavior / white flashing
  - Seems to be some strange interaction with third party transition JS - I disabled the transition for now