### PR TITLE
Additional search design fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,8 +167,7 @@
             transition: undefined,
             duration: 0,
             variation: false
-          },
-          duration: 0
+          }
         });
       });
     </script>

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -5,23 +5,36 @@
 
 .ui.fluid.dropdown {
   width: auto;
-  min-height: unset;
+  min-height: 33px;
   flex-grow: 1;
-  background-color: #000;
-  border: 0.5px #333 transparent;
+  background-color: #333;
+  border: 0.5px rgba(255, 255, 255, 0) solid;
 }
 
-.ui.fluid.dropdown:hover {
-  border-color: rgba(255, 255, 255, 0.4);
-  transition: 0.2s, ease;
+.ui.multiple.dropdown {
+  padding: 0;
+}
+
+.ui.fluid.dropdown:hover, .ui.fluid.dropdown:focus {
+  border: 0.5px rgba(255, 255, 255, 0.4) solid;
+  transition: border 0.2s ease;
 }
 
 .ui.fluid.dropdown > .dropdown.icon {
   color: #222;
 }
 
+.ui.multiple.dropdown > .text,
+.ui.multiple.search.dropdown > .text {
+  margin: 0;
+  padding: 9px 20px;
+ }
+
 .ui.multiple.search.dropdown > input.search {
+  margin: 0;
+  padding: 9px 20px;
   color: #fff;
+  font-size: 13px;
 }
 
 /* Selection Label */
@@ -29,14 +42,22 @@
   background-color: #222;
   color: #fff;
   vertical-align: middle;
-  padding-left: 0.5em;
-  padding-right: 0.5em;
-  border-radius: 10px;
+  margin-top: 0;
+  margin-left: 5px;
+  padding: 5px 10px;
+  border-radius: 15px;
+}
+
+.ui.multiple.dropdown > .label:first-of-type {
+  margin-left: 10px;
+}
+
+.ui.multiple.dropdown > .label:last-of-type {
+  margin-right: -10px;
 }
 
 i.icon.delete {
-  margin-left: 0.25em;
-  border-left: 0.1em rgba(255, 255, 255, 0.1) solid;
+  margin-left: 10px;
 }
 
 i.icon.delete:before {
@@ -59,6 +80,10 @@ i.icon.delete:hover {
   border-color: rgba(255, 255, 255, 0.4);
 }
 
+.ui.dropdown .menu {
+  background: #000;
+}
+
 .ui.selection.active.dropdown .menu {
   min-width: 100%;
   width: 100%;
@@ -72,6 +97,7 @@ i.icon.delete:hover {
 }
 
 .ui.selection.dropdown .menu > .item {
+  padding-left: 20px;
   border-top: 0;
   color: #fff;
   font-size: 13px;


### PR DESCRIPTION
Changes not addressed in #25:

- Adjust padding: 9px 20px
  - New edit: change background color to #333
  - transition: 0.2s, ease;
- Change pill/ tag appearance
- Currently the dropdown is showing a stretching behavior / white flashing