### PR TITLE
Racial disparities scatter plot

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,22 +156,22 @@
       </div>
     </div>
   </body>
-    <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/components/transition.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/components/dropdown.min.js"></script>
-    <script src="src/js/index.js" charset="utf-8"></script>
-    <script>
-      $(document).ready(() => {
-        $('.dropdown').dropdown({
-          fullTextSearch: true,
-          ignoreCase: true,
-          delimiter: ';',
-          label: {
-            transition: undefined,
-            duration: 0,
-            variation: false
-          }
-        });
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/components/transition.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/components/dropdown.min.js"></script>
+  <script src="src/js/index.js" charset="utf-8"></script>
+  <script>
+    $(document).ready(() => {
+      $('.dropdown').dropdown({
+        fullTextSearch: true,
+        ignoreCase: true,
+        delimiter: ';',
+        label: {
+          transition: undefined,
+          duration: 0,
+          variation: false
+        }
       });
-    </script>
+    });
+  </script>
 </html>

--- a/scatter.html
+++ b/scatter.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <div class="container">
-      <div class="graph">
+      <div class="graph" id="race-scatter-plot">
         <h3>Racial Disparities in Cash Bail Across Counties</h3>
         <div class="scatter-plot-subhead">
           <div class="scatter-plot-key">
@@ -19,7 +19,7 @@
           </div>
           <div class="btn-text outliers-btn always-show">Show Outliers</div>
         </div>
-        <div class="scatter-plot" id="race-scatter-plot"></div>
+        <div class="scatter-plot"></div>
       </div>
     </div>
   </body>

--- a/scatter.html
+++ b/scatter.html
@@ -4,7 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>ACLU Cash Bail: Scatter Plot</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/components/transition.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/components/dropdown.min.css">
     <link rel="stylesheet" href="src/css/style.css">
+    <link rel="stylesheet" href="src/css/search.css">
     <link rel="stylesheet" href="src/css/graph.css">
     <link rel="stylesheet" href="src/css/mobile.css">
   </head>
@@ -12,6 +15,12 @@
     <div class="container">
       <div class="graph" id="race-scatter-plot">
         <h3>Racial Disparities in Cash Bail Across Counties</h3>
+        <div class="ui fluid multiple search selection dropdown">
+          <input type="hidden" name="county">
+          <i class="dropdown icon"></i>
+          <div class="default text">Search counties</div>
+          <div class="menu"></div>
+        </div>
         <div class="scatter-plot-subhead">
           <div class="scatter-plot-key">
             <span class="key-circle green">Black Defendents</span>
@@ -25,5 +34,22 @@
       </div>
     </div>
   </body>
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/components/transition.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/components/dropdown.min.js"></script>
   <script src="src/js/scatter-plot.js" charset="utf-8"></script>
+  <script>
+    $(document).ready(() => {
+      $('.dropdown').dropdown({
+        fullTextSearch: true,
+        ignoreCase: true,
+        delimiter: ';',
+        label: {
+          transition: undefined,
+          duration: 0,
+          variation: false
+        }
+      });
+    });
+  </script>
 </html>

--- a/scatter.html
+++ b/scatter.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ACLU Cash Bail: Scatter Plot</title>
+    <link rel="stylesheet" href="src/css/style.css">
+    <link rel="stylesheet" href="src/css/graph.css">
+    <link rel="stylesheet" href="src/css/mobile.css">
+  </head>
+  <body>
+    <div class="container">
+      <div class="graph" id="race-scatter-plot">
+        <h3>Racial Disparities in Cash Bail Across Counties</h3>
+        <div class="scatter-plot-subhead">
+          <div class="scatter-plot-key">
+            <span class="key-circle green">Black Defendents</span>
+            <span class="key-circle purple">White Defendents</span>
+          </div>
+          <div class="btn-text outliers-btn always-show">Show Outliers</div>
+        </div>
+        <div class="scatter-plot"></div>
+      </div>
+    </div>
+  </body>
+  <script src="src/js/scatter-plot.js" charset="utf-8"></script>
+</html>

--- a/scatter.html
+++ b/scatter.html
@@ -26,7 +26,7 @@
             <span class="key-circle green">Black Defendents</span>
             <span class="key-circle purple">White Defendents</span>
           </div>
-          <div class="btn-text outliers-btn always-show">Show Outliers</div>
+          <div class="btn-text outliers-btn">Show Outliers</div>
         </div>
         <div class="plot-container">
           <svg class="scatter-plot" viewBox="0 0 600 500" xmlns="http://www.w3.org/2000/svg"></svg>

--- a/scatter.html
+++ b/scatter.html
@@ -19,7 +19,9 @@
           </div>
           <div class="btn-text outliers-btn always-show">Show Outliers</div>
         </div>
-        <svg class="scatter-plot" viewBox="0 0 600 500" xmlns="http://www.w3.org/2000/svg"></svg>
+        <div class="plot-container">
+          <svg class="scatter-plot" viewBox="0 0 600 500" xmlns="http://www.w3.org/2000/svg"></svg>
+        </div>
       </div>
     </div>
   </body>

--- a/scatter.html
+++ b/scatter.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <div class="container">
-      <div class="graph" id="race-scatter-plot">
+      <div class="graph">
         <h3>Racial Disparities in Cash Bail Across Counties</h3>
         <div class="scatter-plot-subhead">
           <div class="scatter-plot-key">
@@ -19,7 +19,7 @@
           </div>
           <div class="btn-text outliers-btn always-show">Show Outliers</div>
         </div>
-        <div class="scatter-plot"></div>
+        <div class="scatter-plot" id="race-scatter-plot"></div>
       </div>
     </div>
   </body>

--- a/scatter.html
+++ b/scatter.html
@@ -19,7 +19,7 @@
           </div>
           <div class="btn-text outliers-btn always-show">Show Outliers</div>
         </div>
-        <div class="scatter-plot"></div>
+        <svg class="scatter-plot" viewBox="0 0 600 500" xmlns="http://www.w3.org/2000/svg"></svg>
       </div>
     </div>
   </body>

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -16,10 +16,13 @@
 
 .plot-container {
   position: relative;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 50px;
 }
 
 .scatter-plot {
-  width: 100%;
+  width: 600px;
   height: 500px;
   background: rgba(255, 255, 255, 0.05);
   overflow: visible;
@@ -27,7 +30,7 @@
 
 .scatter-plot-subhead {
   position: relative;
-  margin-bottom: 30px 0;
+  margin: 30px 0;
   text-align: center;
 }
 
@@ -171,4 +174,23 @@
 .scatter-tooltip .scatter-tooltip-name {
   width: 80px;
   text-align: left;
+}
+
+@media only screen and (max-width: 640px) {
+  .scatter-plot {
+    width: 300px;
+    height: 400px;
+  }
+}
+
+@media only screen and (max-width: 425px) {
+  .plot-container {
+    padding: 20px;
+    justify-content: flex-end;
+  }
+
+  .scatter-plot {
+    width: 280px;
+    height: 400px;
+  }
 }

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -87,6 +87,7 @@
 .scatter-line.outlier,
 .scatter-text.outlier {
   display: none;
+  opacity: 50%;
 }
 
 .scatter-plot.show-outliers .scatter-line.outlier,
@@ -109,7 +110,6 @@
 }
 
 .scatter-line.hovering, .scatter-point.hovering {
-  /* TODO: what transition to use here? */
   stroke: #FFF;
   stroke-width: 0.5px;
 }

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -172,7 +172,7 @@
 }
 
 .scatter-tooltip td:not(.scatter-tooltip-name) {
-  width: 60px;
+  width: 80px;
   font-family: "GT America Bold";
 }
 

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -1,0 +1,59 @@
+.graph h3 {
+  margin-bottom: 20px;
+  font-family: "GT America Bold";
+  font-size: 13px;
+  font-weight: normal;
+  line-height: 28px;
+  text-align: center;
+  color: #FFF;
+}
+
+.scatter-plot {
+  width: 100%;
+  height: 500px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.scatter-plot-subhead {
+  position: relative;
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.scatter-plot-key {
+  padding: 9px 15px;
+}
+
+.scatter-plot-key span {
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.scatter-plot-key span:not(:last-of-type) {
+  margin-right: 20px;
+}
+
+.key-circle::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  -moz-border-radius: 4px;
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+  margin-right: 8px;
+}
+
+.key-circle.green::before {
+  background-color: #00ED89;
+}
+
+.key-circle.purple::before {
+  background-color: #C14EF8;
+}
+
+.graph .outliers-btn {
+  position: absolute;
+  right: 0;
+  top: 0;
+}

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -18,8 +18,6 @@
   width: 100%;
   height: 500px;
   background: rgba(255, 255, 255, 0.05);
-  border: 0.5px solid rgba(255, 255, 255, 0.18);
-  box-sizing: border-box;
   overflow: visible;
 }
 
@@ -59,13 +57,31 @@
   background-color: #C14EF8;
 }
 
-.scatter-axis {
+.axis-label {
+  fill: #FFF;
+  font-size: 11px;
+  line-height: 13px;
+  text-transform: uppercase;
+}
+
+.label-wrapper {
+  overflow: visible;
+}
+
+.axis-tick {
   fill: rgba(255, 255, 255, 0.75);
   font-size: 11px;
   line-height: 16px;
 }
 
-.scatter-point.outlier, .scatter-line.outlier, .scatter-text.outlier {
+.axis-line {
+  stroke: rgba(255, 255, 255, 0.1);
+  stroke-width: 0.5px;
+}
+
+.scatter-point.outlier,
+.scatter-line.outlier,
+.scatter-text.outlier {
   display: none;
 }
 
@@ -76,7 +92,7 @@
 }
 
 .scatter-line {
-  stroke: rgba(255, 255, 255, 0.18);
+  stroke: rgba(255, 255, 255, 0.2);
   stroke-width: 0.5px;
 }
 
@@ -89,7 +105,8 @@
 }
 
 .scatter-line.hovering, .scatter-point.hovering {
-  stroke: rgba(255, 255, 255, 0.5);
+  /* TODO: what transition to use here? */
+  stroke: #FFF;
   stroke-width: 0.5px;
 }
 

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -27,7 +27,7 @@
 
 .scatter-plot-subhead {
   position: relative;
-  margin-bottom: 30px;
+  margin-bottom: 30px 0;
   text-align: center;
 }
 

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -1,15 +1,3 @@
-line.scatter {
-  stroke: rgba(255, 255, 255, 0.18);
-}
-
-circle.scatter.green {
-  fill: #00ED89;
-}
-
-circle.scatter.purple {
-  fill: #C14EF8;
-}
-
 .graph h3 {
   margin-bottom: 20px;
   font-family: "GT America Bold";
@@ -71,10 +59,38 @@ circle.scatter.purple {
   top: 0;
 }
 
-.scatter.outlier {
+.scatter-point.outlier, .scatter-line.outlier, .scatter-text.outlier {
   display: none;
 }
 
-.scatter-plot.show-outliers .scatter.outlier {
+.scatter-plot.show-outliers .scatter-line.outlier,
+.scatter-plot.show-outliers .scatter-point.outlier,
+.scatter-plot.show-outliers .scatter-text.outlier {
   display: inline-block;
+}
+
+.scatter-line {
+  stroke: rgba(255, 255, 255, 0.18);
+  stroke-width: 0.5px;
+}
+
+.scatter-point.green {
+  fill: #00ED89;
+}
+
+.scatter-point.purple {
+  fill: #C14EF8;
+}
+
+.scatter-line.hovering, .scatter-point.hovering {
+  stroke: rgba(255, 255, 255, 0.5);
+  stroke-width: 0.5px;
+}
+
+.scatter-text {
+  fill: #FFF;
+  font-size: 11px;
+  line-height: 16px;
+  margin-top: 4px;
+  cursor: default;
 }

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -180,7 +180,8 @@
   text-align: left;
 }
 
-@media only screen and (max-width: 640px) {
+/* these are custom breakpoints to make the svg work well on phones */
+@media only screen and (max-width: 670px) {
   .scatter-plot {
     width: 300px;
     height: 400px;
@@ -218,7 +219,7 @@
   }
 }
 
-@media only screen and (max-width: 425px) {
+@media only screen and (max-width: 400px) {
   .plot-container {
     padding: 20px;
     justify-content: flex-end;

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -1,3 +1,15 @@
+line.scatter {
+  stroke: rgba(255, 255, 255, 0.18);
+}
+
+circle.scatter.green {
+  fill: #00ED89;
+}
+
+circle.scatter.purple {
+  fill: #C14EF8;
+}
+
 .graph h3 {
   margin-bottom: 20px;
   font-family: "GT America Bold";
@@ -9,11 +21,12 @@
 }
 
 .scatter-plot {
-  position: relative;
   width: 100%;
   height: 500px;
   background: rgba(255, 255, 255, 0.05);
   border: 0.5px solid rgba(255, 255, 255, 0.18);
+  box-sizing: border-box;
+  overflow: visible;
 }
 
 .scatter-plot-subhead {
@@ -58,26 +71,10 @@
   top: 0;
 }
 
-.scatter-point {
-  position: absolute;
-  display: inline-block;
-  height: 8px;
-  width: 8px;
-  border-radius: 50%;
-}
-
-.scatter-point.green {
-  background-color: #00ED89;
-}
-
-.scatter-point.purple {
-  background-color: #C14EF8;
-}
-
-.scatter-point.outlier {
+.scatter.outlier {
   display: none;
 }
 
-.scatter-plot.show-outliers .scatter-point.outlier {
+.scatter-plot.show-outliers .scatter.outlier {
   display: inline-block;
 }

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -14,6 +14,10 @@
   top: 0;
 }
 
+.plot-container {
+  position: relative;
+}
+
 .scatter-plot {
   width: 100%;
   height: 500px;
@@ -115,4 +119,56 @@
   font-size: 11px;
   line-height: 16px;
   cursor: default;
+}
+
+.scatter-tooltip {
+  display: inline-block;
+  position: absolute;
+  width: 260px;
+  margin: 20px 0 0 20px;
+  padding: 11px;
+  background-color: #FFF;
+  border: 1px solid #DCDCDC;
+  border-radius: 4px;
+  box-sizing: border-box;
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.25);
+  font-size: 12px;
+  line-height: 13px;
+  color: #000;
+}
+
+.scatter-tooltip h4 {
+  margin: 0;
+  font-family: "GT America Bold";
+  font-weight: 400;
+}
+
+.scatter-tooltip table {
+  border-collapse: collapse;
+}
+
+.scatter-tooltip tbody tr {
+  border-top: 0.5px solid #D6D6D6;
+}
+
+.scatter-tooltip th {
+  padding: 5px;
+  font-family: "GT America Condensed";
+  font-weight: 400;
+  text-align: right;
+  text-transform: uppercase;
+  vertical-align: bottom;
+}
+
+.scatter-tooltip td {
+  width: 60px;
+  padding: 5px;
+  text-align: right;
+  text-transform: capitalize;
+  font-variant-numeric: tabular-nums;
+}
+
+.scatter-tooltip .scatter-tooltip-name {
+  width: 80px;
+  text-align: left;
 }

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -125,7 +125,6 @@
 }
 
 .scatter-tooltip {
-  display: inline-block;
   position: absolute;
   width: 260px;
   margin: 20px 0 0 20px;
@@ -147,6 +146,8 @@
 }
 
 .scatter-tooltip table {
+  width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
 }
 
@@ -155,7 +156,7 @@
 }
 
 .scatter-tooltip th {
-  padding: 5px;
+  padding: 5px 0;
   font-family: "GT America Condensed";
   font-weight: 400;
   text-align: right;
@@ -164,15 +165,18 @@
 }
 
 .scatter-tooltip td {
-  width: 60px;
-  padding: 5px;
+  padding: 5px 0;
   text-align: right;
   text-transform: capitalize;
   font-variant-numeric: tabular-nums;
 }
 
+.scatter-tooltip td:not(.scatter-tooltip-name) {
+  width: 60px;
+  font-family: "GT America Bold";
+}
+
 .scatter-tooltip .scatter-tooltip-name {
-  width: 80px;
   text-align: left;
 }
 
@@ -180,6 +184,37 @@
   .scatter-plot {
     width: 300px;
     height: 400px;
+  }
+
+  .plot-container {
+    position: static;
+  }
+
+  .scatter-tooltip {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    margin: 0;
+    padding: 20px;
+    background-color: #000;
+    border: none;
+    border-top: 1px solid #FFF;
+    border-radius: 0;
+    box-shadow: none;
+    color: #FFF;
+  }
+
+  .scatter-tooltip tbody tr {
+    border-top: none;
+  }
+
+  .scatter-tooltip td {
+    width: 100px;
+  }
+
+  .scatter-tooltip .scatter-tooltip-name {
+    width: calc(100% - 200px);
   }
 }
 

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -73,3 +73,11 @@
 .scatter-point.purple {
   background-color: #C14EF8;
 }
+
+.scatter-point.outlier {
+  display: none;
+}
+
+.scatter-plot.show-outliers .scatter-point.outlier {
+  display: inline-block;
+}

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -8,6 +8,12 @@
   color: #FFF;
 }
 
+.graph .outliers-btn {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
 .scatter-plot {
   width: 100%;
   height: 500px;
@@ -53,10 +59,10 @@
   background-color: #C14EF8;
 }
 
-.graph .outliers-btn {
-  position: absolute;
-  right: 0;
-  top: 0;
+.scatter-axis {
+  fill: rgba(255, 255, 255, 0.75);
+  font-size: 11px;
+  line-height: 16px;
 }
 
 .scatter-point.outlier, .scatter-line.outlier, .scatter-text.outlier {
@@ -91,6 +97,5 @@
   fill: #FFF;
   font-size: 11px;
   line-height: 16px;
-  margin-top: 4px;
   cursor: default;
 }

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -100,11 +100,11 @@
   stroke-width: 0.5px;
 }
 
-.scatter-point.green {
+.scatter-point.black {
   fill: #00ED89;
 }
 
-.scatter-point.purple {
+.scatter-point.white {
   fill: #C14EF8;
 }
 

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -9,9 +9,11 @@
 }
 
 .scatter-plot {
+  position: relative;
   width: 100%;
   height: 500px;
   background: rgba(255, 255, 255, 0.05);
+  border: 0.5px solid rgba(255, 255, 255, 0.18);
 }
 
 .scatter-plot-subhead {
@@ -38,9 +40,7 @@
   display: inline-block;
   width: 8px;
   height: 8px;
-  -moz-border-radius: 4px;
-  -webkit-border-radius: 4px;
-  border-radius: 4px;
+  border-radius: 50%;
   margin-right: 8px;
 }
 
@@ -56,4 +56,20 @@
   position: absolute;
   right: 0;
   top: 0;
+}
+
+.scatter-point {
+  position: absolute;
+  display: inline-block;
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+}
+
+.scatter-point.green {
+  background-color: #00ED89;
+}
+
+.scatter-point.purple {
+  background-color: #C14EF8;
 }

--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -65,14 +65,8 @@
     padding: 10px;
   }
 
-  .outliers-btn:not(.always-show) {
+  .outliers-btn {
     display: none;
-  }
-
-  .outliers-btn.always-show {
-    max-width: 161px;
-    position: relative;
-    margin: auto;
   }
 
   .outliers-btn.mobile-only {

--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -65,8 +65,14 @@
     padding: 10px;
   }
 
-  .outliers-btn {
+  .outliers-btn:not(.always-show) {
     display: none;
+  }
+
+  .outliers-btn.always-show {
+    max-width: 161px;
+    position: relative;
+    margin: auto;
   }
 
   .outliers-btn.mobile-only {

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -115,7 +115,7 @@ i.icon.delete:hover {
 }
 
 .ui.selection.dropdown .menu > .item.bold {
-  font-weight: 700;
+  font-family: "GT America Bold";
 }
 
 .ui.dropdown.selected, .ui.dropdown .menu .selected.item,

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -114,6 +114,10 @@ i.icon.delete:hover {
   font-size: 13px;
 }
 
+.ui.selection.dropdown .menu > .item.bold {
+  font-weight: 700;
+}
+
 .ui.dropdown.selected, .ui.dropdown .menu .selected.item,
 .ui.dropdown .menu > .item:hover {
   background-color: #222;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -3,6 +3,16 @@
   src: url("./GT-America-Standard-Regular.otf") format("opentype");
 }
 
+@font-face {
+  font-family: "GT America Bold";
+  src: url("./GT-America-Standard-Bold.otf") format("opentype");
+}
+
+@font-face {
+  font-family: "GT America Condensed";
+  src: url("./GT-America-Condensed-Regular.otf") format("opentype");
+}
+
 body {
   font-family: "GT America";
   font-size: 13px;
@@ -34,4 +44,27 @@ body {
 
 .mobile-only {
   display: none;
+}
+
+.btn-text {
+  color: #fff;
+  font-family: "GT America Bold";
+  font-weight: 600;
+  font-size: 11px;
+  text-align: center;
+  text-transform: uppercase;
+  border-radius: 3px;
+}
+
+.outliers-btn {
+  margin-left: 1em;
+  padding: 10px 15px;
+  border: 1px #333 solid;
+  cursor: pointer;
+  user-select: none;
+}
+
+.outliers-btn.showing {
+  color: #fff;
+  background-color: #1D1D1D;
 }

--- a/src/css/table.css
+++ b/src/css/table.css
@@ -1,13 +1,3 @@
-@font-face {
-  font-family: "GT America Condensed";
-  src: url("./GT-America-Condensed-Regular.otf") format("opentype");
-}
-
-@font-face {
-  font-family: "GT America Bold";
-  src: url("./GT-America-Standard-Bold.otf") format("opentype");
-}
-
 table {
   border-collapse: collapse;
   max-width: 600px;
@@ -151,33 +141,10 @@ td.bold-cell {
   color: #fff;
 }
 
-.btn-text {
-  color: #fff;
-  font-family: "GT America Bold";
-  font-weight: 600;
-  font-size: 11px;
-  text-align: center;
-  text-transform: uppercase;
-  border-radius: 3px;
-}
-
 .view-all-btn {
   margin: 1.5em 0;
   cursor: pointer;
   user-select: none;
-}
-
-.outliers-btn {
-  margin-left: 1em;
-  padding: 10px 15px;
-  border: 1px #333 solid;
-  cursor: pointer;
-  user-select: none;
-}
-
-.outliers-btn.showing {
-  color: #fff;
-  background-color: #1D1D1D;
 }
 
 .switch-container {

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -50,7 +50,7 @@ class CountyPoint {
 
   renderPoints() {
     this.data.forEach((data, i) => {
-      const className = `${data.class} scatter-point${this.outlier ? " outlier" : ""}`;
+      const className = `${data.name} scatter-point${this.outlier ? " outlier" : ""}`;
       const point = document.createElementNS(SVG_NS, "circle");
       point.setAttributeNS(null, "class", className);
       point.setAttributeNS(null, "cx", this.xs[i]);
@@ -179,16 +179,15 @@ export class ScatterPlot {
     for (const county in this.data) {
       const outlier = this.data[county]["outlier"];
       const showName = this.data[county]["showName"];
-      const rate = this.data[county]["bailRate"];
-      const amount = this.data[county]["bailAmount"];
-      const data = ["black", "white"].map(key => {
+      const x = this.data[county]["x"];
+      const y = this.data[county]["y"];
+      const data = Object.keys(x).map(key => {
         return {
           name: key,
-          class: key == "black" ? "green" : "purple",
-          x: rate[key],
-          y: Number(amount[key].replace(/[^\d.-]/g, "")),
-          xText: this.toText.x(rate[key]),
-          yText: this.toText.y(amount[key]),
+          x: x[key],
+          y: Number(y[key].replace(/[^\d.-]/g, "")),
+          xText: this.toText.x(x[key]),
+          yText: this.toText.y(y[key]),
           xHeader: this.toText.xHeader,
           yHeader: this.toText.yHeader
         };

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -1,8 +1,58 @@
+const POINT_RADIUS = 4;
+
+class CountyPoint {
+  constructor(county, data, xAxis, yAxis, outlier, container) {
+    this.county = county;
+    this.data = data;
+    this.xAxis = xAxis;
+    this.yAxis = yAxis;
+    this.outlier = outlier;
+    this.container = container;
+  }
+
+  render() {
+    for (const data of this.data) {
+      const point = document.createElement("div");
+      point.className = `${data.class} scatter-point`;
+      point.style.left = `calc(${data.x / this.xAxis.max * 100}% - ${POINT_RADIUS}px`;
+      point.style.bottom = `calc(${data.y / this.yAxis.max * 100}% - ${POINT_RADIUS}px`;
+      this.container.appendChild(point);
+    }
+  }
+}
+
 export class ScatterPlot {
   constructor(data, xAxis, yAxis, container) {
     this.data = data;
     this.xAxis = xAxis;
     this.yAxis = yAxis;
     this.container = container;
+    this.points = this.createPoints();
+    console.log(this.points);
+    this.render();
+  }
+
+  createPoints() {
+    const points = [];
+    for (const county in this.data) {
+      const outlier = this.data[county]["outlier"];
+      const rate = this.data[county]["bailRate"];
+      const amount = this.data[county]["bailAmount"];
+      const data = ["black", "white"].map(key => {
+        return {
+          class: key == "black" ? "green" : "purple",
+          x: rate[key],
+          y: Number(amount[key].replace(/[^\d.-]/g, ""))
+        };
+      });
+      points.push(new CountyPoint(
+        county, data, this.xAxis, this.yAxis, outlier, this.container
+      ));
+    }
+    return points;
+  }
+
+  render() {
+    this.points.forEach(point => point.render());
   }
 }

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -1,4 +1,5 @@
 const POINT_RADIUS = 4;
+const SVG_NS = "http://www.w3.org/2000/svg";
 
 class CountyPoint {
   constructor(county, data, xAxis, yAxis, outlier, plot) {
@@ -8,22 +9,46 @@ class CountyPoint {
     this.yAxis = yAxis;
     this.outlier = outlier;
     this.plot = plot;
+    [this.xs, this.ys] = this.getPositions();
   }
 
   isOutlier() {
     return this.outlier;
   }
 
-  render() {
+  getPositions() {
+    const xs = [], ys = [];
     for (const data of this.data) {
-      const point = document.createElement("div");
-      let className = `${data.class} scatter-point`;
-      if (this.outlier) className += " outlier";
-      point.className = className;
-      point.style.left = `calc(${data.x / this.xAxis.max * 100}% - ${POINT_RADIUS}px`;
-      point.style.bottom = `calc(${data.y / this.yAxis.max * 100}% - ${POINT_RADIUS}px`;
-      this.plot.appendChild(point);
+      xs.push(`${data.x / this.xAxis.max * 100}%`);
+      // svgs start Y from the top, so subtract the percentage from 100
+      ys.push(`${100 - (data.y / this.yAxis.max * 100)}%`);
     }
+    return [xs, ys];
+  }
+
+  renderPoints() {
+    this.data.forEach((data, i) => {
+      let className = `${data.class} scatter${this.outlier ? " outlier" : ""}`;
+      const point = document.createElementNS(SVG_NS, "circle");
+      point.setAttributeNS(null, "class", className);
+      point.setAttributeNS(null, "cx", this.xs[i]);
+      point.setAttributeNS(null, "cy", this.ys[i]);
+      point.setAttributeNS(null, "r", POINT_RADIUS);
+      this.plot.appendChild(point)
+    });
+  }
+
+  renderLine() {
+    if (this.data.length != 2) return;
+
+    const line = document.createElementNS(SVG_NS, "line");
+    let className = `scatter${this.outlier ? " outlier" : ""}`;
+    line.setAttributeNS(null, "class", className);
+    line.setAttributeNS(null, "x1", this.xs[0]);
+    line.setAttributeNS(null, "y1", this.ys[0]);
+    line.setAttributeNS(null, "x2", this.xs[1]);
+    line.setAttributeNS(null, "y2", this.ys[1]);
+    this.plot.appendChild(line);
   }
 }
 
@@ -79,6 +104,8 @@ export class ScatterPlot {
   }
 
   render() {
-    this.points.forEach(point => point.render());
+    // render all lines first so that points are on top
+    this.points.forEach(point => point.renderLine());
+    this.points.forEach(point => point.renderPoints());
   }
 }

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -166,6 +166,7 @@ export class ScatterPlot {
     this.plotContainer = this.container.getElementsByClassName("plot-container")[0];
     this.plot = this.container.getElementsByClassName("scatter-plot")[0];
     this.points = this.createPoints();
+    this.mobileSizing = window.innerWidth < 640;
     this.showOutliers = false;
     this.setUpSearchBar();
     this.setUpOutlierButton();
@@ -199,6 +200,7 @@ export class ScatterPlot {
 
   setUpOutlierButton() {
     const button = this.container.getElementsByClassName("outliers-btn")[0];
+    if (this.mobileSizing) this.plot.classList.add("show-outliers");
     button.addEventListener("click", (e) => {
       if (this.toggleOutliers()) {
         e.target.classList.add("showing");
@@ -244,7 +246,7 @@ export class ScatterPlot {
 
   toggleOutliers() {
     this.showOutliers = !this.showOutliers;
-    return this.showOutliers;
+    return this.showOutliers || this.mobileSizing;
   }
 
   updateViewBox() {

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -2,12 +2,13 @@ const POINT_RADIUS = 4;
 const SVG_NS = "http://www.w3.org/2000/svg";
 
 class CountyPoint {
-  constructor(county, data, xAxis, yAxis, outlier, plot) {
+  constructor(county, data, xAxis, yAxis, outlier, showName, plot) {
     this.county = county;
     this.data = data;
     this.xAxis = xAxis;
     this.yAxis = yAxis;
     this.outlier = outlier;
+    this.showName = showName;
     this.plot = plot;
     [this.xs, this.ys] = this.getPositions();
   }
@@ -26,29 +27,82 @@ class CountyPoint {
     return [xs, ys];
   }
 
+  renderCountyName() {
+    if (!this.showName) return;
+
+    const className = `scatter-text${this.outlier ? " outlier" : ""}`;
+    const text = document.createElementNS(SVG_NS, "text");
+    text.setAttributeNS(null, "class", className);
+    text.setAttributeNS(null, "x", this.xs[0]);
+    text.setAttributeNS(null, "y", this.ys[0]);
+    text.setAttributeNS(null, "dx", 11);
+    text.setAttributeNS(null, "dy", 3);
+    text.appendChild(document.createTextNode(this.county));
+    this.plot.appendChild(text);
+
+    this.text = text;
+    text.addEventListener("mouseenter", () => this.onMouseEnter());
+    text.addEventListener("mouseleave", () => this.onMouseLeave());
+  }
+
   renderPoints() {
+    this.points = [];
     this.data.forEach((data, i) => {
-      let className = `${data.class} scatter${this.outlier ? " outlier" : ""}`;
+      const className = `${data.class} scatter-point${this.outlier ? " outlier" : ""}`;
       const point = document.createElementNS(SVG_NS, "circle");
       point.setAttributeNS(null, "class", className);
       point.setAttributeNS(null, "cx", this.xs[i]);
       point.setAttributeNS(null, "cy", this.ys[i]);
       point.setAttributeNS(null, "r", POINT_RADIUS);
-      this.plot.appendChild(point)
+      this.plot.appendChild(point);
+
+      this.points.push(point);
+      point.addEventListener("mouseenter", () => this.onMouseEnter());
+      point.addEventListener("mouseleave", () => this.onMouseLeave());
     });
   }
 
   renderLine() {
+    // only draw line if we have two data points
     if (this.data.length != 2) return;
 
+    const className = `scatter-line${this.outlier ? " outlier" : ""}`;
     const line = document.createElementNS(SVG_NS, "line");
-    let className = `scatter${this.outlier ? " outlier" : ""}`;
     line.setAttributeNS(null, "class", className);
     line.setAttributeNS(null, "x1", this.xs[0]);
     line.setAttributeNS(null, "y1", this.ys[0]);
     line.setAttributeNS(null, "x2", this.xs[1]);
     line.setAttributeNS(null, "y2", this.ys[1]);
     this.plot.appendChild(line);
+
+    this.line = line;
+    line.addEventListener("mouseenter", () => this.onMouseEnter());
+    line.addEventListener("mouseleave", () => this.onMouseLeave());
+  }
+
+  onMouseEnter() {
+    console.log(this.county);
+    this.points.forEach(point => {
+      point.classList.add("hovering");
+    });
+    this.line.classList.add("hovering");
+    if (this.text) this.text.classList.add("hovering");
+  }
+
+  onMouseLeave() {
+    this.points.forEach(point => {
+      point.classList.remove("hovering");
+    });
+    this.line.classList.remove("hovering");
+    if (this.text) this.text.classList.remove("hovering");
+  }
+
+  rerenderPoints() {
+    this.data.forEach(data => {
+      const use = document.createElementNS(SVG_NS, "use");
+      use.setAttributeNS(null, "href", `#${this.county}-${data.class}`);
+      this.plot.appendChild(use);
+    });
   }
 }
 
@@ -82,6 +136,7 @@ export class ScatterPlot {
     const points = [];
     for (const county in this.data) {
       const outlier = this.data[county]["outlier"];
+      const showName = this.data[county]["showName"];
       const rate = this.data[county]["bailRate"];
       const amount = this.data[county]["bailAmount"];
       const data = ["black", "white"].map(key => {
@@ -91,8 +146,8 @@ export class ScatterPlot {
           y: Number(amount[key].replace(/[^\d.-]/g, ""))
         };
       });
-      points.push(
-        new CountyPoint(county, data, this.xAxis, this.yAxis, outlier, this.plot
+      points.push(new CountyPoint(
+          county, data, this.xAxis, this.yAxis, outlier, showName, this.plot
       ));
     }
     return points;
@@ -104,8 +159,8 @@ export class ScatterPlot {
   }
 
   render() {
-    // render all lines first so that points are on top
     this.points.forEach(point => point.renderLine());
     this.points.forEach(point => point.renderPoints());
+    this.points.forEach(point => point.renderCountyName());
   }
 }

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -166,7 +166,7 @@ export class ScatterPlot {
     this.plotContainer = this.container.getElementsByClassName("plot-container")[0];
     this.plot = this.container.getElementsByClassName("scatter-plot")[0];
     this.points = this.createPoints();
-    this.mobileSizing = window.innerWidth < 640;
+    this.mobileSizing = window.innerWidth < 670;
     this.showOutliers = false;
     this.setUpSearchBar();
     this.setUpOutlierButton();
@@ -250,7 +250,7 @@ export class ScatterPlot {
   }
 
   updateViewBox() {
-    this.mobileSizing = window.innerWidth < 640;
+    this.mobileSizing = window.innerWidth < 670;
     // rerender axes with new mobile sizing value
     this.renderAxis(this.xAxis, false);
     this.renderAxis(this.yAxis, true);
@@ -258,10 +258,11 @@ export class ScatterPlot {
     // set points to use fixed positioning for mobile or on point for not
     this.points.forEach(point => point.setTooltipFixed(this.mobileSizing));
 
-    // set viewbox based on window size
-    const innerWidth = window.innerWidth;
-    const width = innerWidth < 425 ? 280 : innerWidth < 640 ? 300 : 600;
-    const height = window.innerWidth < 640 ? 400 : 500;
+    // set viewbox based on window size (customized for specific phones)
+    const iPhoneSE = window.innerWidth < 350;
+    const iPhone8 = window.innerWidth < 400;
+    const width = iPhoneSE ? 180 : iPhone8 ? 280 : this.mobileSizing ? 300 : 600;
+    const height = this.mobileSizing ? 400 : 500;
     this.plot.setAttributeNS(null, "viewBox", `0 0 ${width} ${height}`);
   }
 

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -1,0 +1,8 @@
+export class ScatterPlot {
+  constructor(data, xAxis, yAxis, container) {
+    this.data = data;
+    this.xAxis = xAxis;
+    this.yAxis = yAxis;
+    this.container = container;
+  }
+}

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -1,22 +1,28 @@
 const POINT_RADIUS = 4;
 
 class CountyPoint {
-  constructor(county, data, xAxis, yAxis, outlier, container) {
+  constructor(county, data, xAxis, yAxis, outlier, plot) {
     this.county = county;
     this.data = data;
     this.xAxis = xAxis;
     this.yAxis = yAxis;
     this.outlier = outlier;
-    this.container = container;
+    this.plot = plot;
+  }
+
+  isOutlier() {
+    return this.outlier;
   }
 
   render() {
     for (const data of this.data) {
       const point = document.createElement("div");
-      point.className = `${data.class} scatter-point`;
+      let className = `${data.class} scatter-point`;
+      if (this.outlier) className += " outlier";
+      point.className = className;
       point.style.left = `calc(${data.x / this.xAxis.max * 100}% - ${POINT_RADIUS}px`;
       point.style.bottom = `calc(${data.y / this.yAxis.max * 100}% - ${POINT_RADIUS}px`;
-      this.container.appendChild(point);
+      this.plot.appendChild(point);
     }
   }
 }
@@ -27,9 +33,24 @@ export class ScatterPlot {
     this.xAxis = xAxis;
     this.yAxis = yAxis;
     this.container = container;
+    this.plot = this.container.getElementsByClassName("scatter-plot")[0];
     this.points = this.createPoints();
-    console.log(this.points);
+    this.showOutliers = false;
+    this.setUpOutlierButton();
     this.render();
+  }
+
+  setUpOutlierButton() {
+    const button = this.container.getElementsByClassName("outliers-btn")[0];
+    button.addEventListener("click", (e) => {
+      if (this.toggleOutliers()) {
+        e.target.classList.add("showing");
+        this.plot.classList.add("show-outliers");
+      } else {
+        e.target.classList.remove("showing");
+        this.plot.classList.remove("show-outliers");
+      }
+    });
   }
 
   createPoints() {
@@ -45,11 +66,16 @@ export class ScatterPlot {
           y: Number(amount[key].replace(/[^\d.-]/g, ""))
         };
       });
-      points.push(new CountyPoint(
-        county, data, this.xAxis, this.yAxis, outlier, this.container
+      points.push(
+        new CountyPoint(county, data, this.xAxis, this.yAxis, outlier, this.plot
       ));
     }
     return points;
+  }
+
+  toggleOutliers() {
+    this.showOutliers = !this.showOutliers;
+    return this.showOutliers;
   }
 
   render() {

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -325,22 +325,31 @@ export class ScatterPlot {
   }
 
   renderAxisLabels(axis, isYAxis, isLower) {
+    // for mobile we only need one label
+    if (this.mobileSizing && !isLower) return;
+
     // wrap axis labels in svgs to do local rotation
     const wrapper = document.createElementNS(SVG_NS, "svg");
     wrapper.setAttributeNS(null, "class", "label-wrapper");
-    wrapper.setAttributeNS(null, "x", isLower ? 0 : isYAxis ? 0 : "100%");
-    wrapper.setAttributeNS(null, "y", isLower ? "100%" : isYAxis ? 0 : "100%");
+    if (this.mobileSizing) {
+      wrapper.setAttributeNS(null, "x", isYAxis ? 0 : "50%");
+      wrapper.setAttributeNS(null, "y", isYAxis ? "50%" : "100%");
+    } else {
+      wrapper.setAttributeNS(null, "x", isLower ? 0 : isYAxis ? 0 : "100%");
+      wrapper.setAttributeNS(null, "y", isLower ? "100%" : isYAxis ? 0 : "100%");
+    }
 
     // get offset based on window size
     const dy = this.mobileSizing ? 40 : 60;
 
     const label = document.createElementNS(SVG_NS, "text");
+    const textAnchor = this.mobileSizing ? "middle" : isLower ? "start" : "end";
     label.setAttributeNS(null, "class", "axis-label");
-    label.setAttributeNS(null, "text-anchor", isLower ? "start" : "end");
+    label.setAttributeNS(null, "text-anchor", textAnchor);
     label.setAttributeNS(null, "dy", isYAxis ? -dy : dy);
     if (isYAxis) label.setAttributeNS(null, "transform", "rotate(-90)");
     const text = isLower ? `← Lower ${axis.name}` : `Higher ${axis.name} →`;
-    label.appendChild(document.createTextNode(text));
+    label.appendChild(document.createTextNode(this.mobileSizing ? axis.name : text));
     wrapper.appendChild(label);
     this.axisLabels[isYAxis ? "y" : "x"].push(wrapper);
     this.plot.appendChild(wrapper);

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -157,8 +157,40 @@ export class ScatterPlot {
     this.plot = this.container.getElementsByClassName("scatter-plot")[0];
     this.points = this.createPoints();
     this.showOutliers = false;
+    this.setUpSearchBar();
     this.setUpOutlierButton();
     this.render();
+  }
+
+  setUpSearchBar() {
+    const stateAvg = "State Average";
+    const searchMenu = this.container.getElementsByClassName("menu")[0];
+    const counties = Object.keys(this.data).filter(c => c !== stateAvg).sort();
+    // make sure state average appears at the beginning of the search
+    counties.unshift(stateAvg);
+    counties.forEach(county => {
+      const element = document.createElement("div");
+      // state average should be bolded
+      element.className = county === stateAvg ? "item bold" : "item";
+      element.innerText = county;
+      searchMenu.appendChild(element);
+    });
+
+    const searchInput = this.container.getElementsByTagName("input")[0];
+    searchInput.addEventListener("change", e => {
+      const searchValue = e.target.value;
+      this.searchTerms = searchValue.split(";").filter(s => s !== "");
+      this.points.forEach(point => {
+        point.elements.forEach(element => {
+          // add or remove hovering class based on if county is selected
+          if (this.searchTerms.includes(point.county.toLowerCase())) {
+            element.classList.add("hovering");
+          } else {
+            element.classList.remove("hovering");
+          }
+        });
+      });
+    });
   }
 
   setUpOutlierButton() {

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -1,4 +1,3 @@
-const POINT_RADIUS = 4;
 const SVG_NS = "http://www.w3.org/2000/svg";
 
 class CountyPoint {
@@ -19,13 +18,13 @@ class CountyPoint {
 
   getPositions() {
     const xs = [], ys = [];
-    for (const data of this.data) {
+    this.data.forEach(data => {
       const xDiff = this.xAxis.max - this.xAxis.min;
       const yDiff = this.yAxis.max - this.yAxis.min;
       xs.push(`${(data.x - this.xAxis.min) / xDiff * 100}%`);
       // svgs start Y from the top, so subtract the percentage from 100
       ys.push(`${100 - ((data.y - this.yAxis.min) / yDiff * 100)}%`);
-    }
+    });
     return [xs, ys];
   }
 
@@ -55,7 +54,7 @@ class CountyPoint {
       point.setAttributeNS(null, "class", className);
       point.setAttributeNS(null, "cx", this.xs[i]);
       point.setAttributeNS(null, "cy", this.ys[i]);
-      point.setAttributeNS(null, "r", POINT_RADIUS);
+      point.setAttributeNS(null, "r", 4);
       this.plot.appendChild(point);
 
       this.points.push(point);
@@ -98,15 +97,8 @@ class CountyPoint {
     this.line.classList.remove("hovering");
     if (this.text) this.text.classList.remove("hovering");
   }
-
-  rerenderPoints() {
-    this.data.forEach(data => {
-      const use = document.createElementNS(SVG_NS, "use");
-      use.setAttributeNS(null, "href", `#${this.county}-${data.class}`);
-      this.plot.appendChild(use);
-    });
-  }
 }
+
 
 export class ScatterPlot {
   constructor(data, xAxis, yAxis, container) {
@@ -149,7 +141,7 @@ export class ScatterPlot {
         };
       });
       points.push(new CountyPoint(
-          county, data, this.xAxis, this.yAxis, outlier, showName, this.plot
+        county, data, this.xAxis, this.yAxis, outlier, showName, this.plot
       ));
     }
     return points;

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -4734,6 +4734,7 @@ export const BAIL_RACE_AMOUNT_DATA = [
 
 export const RACE_SCATTER_PLOT = {
   "Cameron": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 100,
@@ -4745,6 +4746,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Forest": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 85,
@@ -4756,6 +4758,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Potter": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 75,
@@ -4767,6 +4770,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Somerset": {
+    "showName": true,
     "outlier": false,
     "bailRate": {
       "black": 69.56521739,
@@ -4778,6 +4782,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Jefferson": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 72.97297297,
@@ -4789,6 +4794,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Warren": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 70,
@@ -4800,6 +4806,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Sullivan": {
+    "showName": true,
     "outlier": true,
     "bailRate": {
       "black": 62.5,
@@ -4811,6 +4818,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Wayne": {
+    "showName": true,
     "outlier": false,
     "bailRate": {
       "black": 64.86486486,
@@ -4822,6 +4830,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Blair": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 58.6998088,
@@ -4833,6 +4842,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Lycoming": {
+    "showName": true,
     "outlier": false,
     "bailRate": {
       "black": 55.01355014,
@@ -4844,6 +4854,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Susquehanna": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 66.66666667,
@@ -4855,6 +4866,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Erie": {
+    "showName": true,
     "outlier": false,
     "bailRate": {
       "black": 63.73239437,
@@ -4866,6 +4878,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Cambria": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 65.52083333,
@@ -4877,6 +4890,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Huntingdon": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 64.05228758,
@@ -4888,6 +4902,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Crawford": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 53.33333333,
@@ -4899,6 +4914,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Centre": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 46.74115456,
@@ -4910,6 +4926,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Venango": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 60.13986014,
@@ -4921,6 +4938,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Clearfield": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 59.30232558,
@@ -4932,6 +4950,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Armstrong": {
+    "showName": true,
     "outlier": false,
     "bailRate": {
       "black": 62.71186441,
@@ -4943,6 +4962,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Northumberland": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 56.81818182,
@@ -4954,6 +4974,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Lawrence": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 66.28477905,
@@ -4965,6 +4986,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Mifflin": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 70.11494253,
@@ -4976,6 +4998,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Tioga": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 57,
@@ -4987,6 +5010,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Allegheny": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 57.06645057,
@@ -4998,6 +5022,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Westmoreland": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 50.05045409,
@@ -5009,6 +5034,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Greene": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 58.97435897,
@@ -5020,6 +5046,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Beaver": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 64.33048433,
@@ -5031,6 +5058,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "McKean": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 61.33333333,
@@ -5042,6 +5070,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Washington": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 55.77092511,
@@ -5053,6 +5082,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Luzerne": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 53.5892323,
@@ -5064,6 +5094,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Lackawanna": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 67.1345995,
@@ -5075,6 +5106,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Snyder": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 52.5,
@@ -5086,6 +5118,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Bradford": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 62.26415094,
@@ -5097,6 +5130,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Cumberland": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 51.61744023,
@@ -5108,6 +5142,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Butler": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 44.7761194,
@@ -5119,6 +5154,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Delaware": {
+    "showName": true,
     "outlier": false,
     "bailRate": {
       "black": 63.75237882,
@@ -5130,6 +5166,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Bedford": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 52.57731959,
@@ -5141,6 +5178,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Union": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 38.20224719,
@@ -5152,6 +5190,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Dauphin": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 51.21710526,
@@ -5163,6 +5202,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Montgomery": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 43.27198364,
@@ -5174,6 +5214,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Adams": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 43.56060606,
@@ -5185,6 +5226,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Chester": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 48.47354138,
@@ -5196,6 +5238,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Franklin": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 49.26553672,
@@ -5207,6 +5250,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "York": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 54.11985019,
@@ -5218,6 +5262,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Philadelphia": {
+    "showName": true,
     "outlier": false,
     "bailRate": {
       "black": 56.02170568,
@@ -5229,6 +5274,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Lancaster": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 55.54532904,
@@ -5240,6 +5286,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Perry": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 40,
@@ -5251,6 +5298,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Mercer": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 45.40337711,
@@ -5262,6 +5310,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Northampton": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 55.7063541,
@@ -5273,6 +5322,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Fayette": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 54,
@@ -5284,6 +5334,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Carbon": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 43.7751004,
@@ -5295,6 +5346,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Clinton": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 47.14285714,
@@ -5306,6 +5358,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Lebanon": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 48.84547069,
@@ -5317,6 +5370,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Montour": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 46.15384615,
@@ -5328,6 +5382,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Bucks": {
+    "showName": true,
     "outlier": false,
     "bailRate": {
       "black": 41.06901218,
@@ -5339,6 +5394,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Schuylkill": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 46.5060241,
@@ -5350,6 +5406,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Lehigh": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 61.81634031,
@@ -5361,6 +5418,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Berks": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 58.42078961,
@@ -5372,6 +5430,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Juniata": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 43.75,
@@ -5383,6 +5442,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Wyoming": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 40,
@@ -5394,6 +5454,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Pike": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 37.41007194,
@@ -5405,6 +5466,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Monroe": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 35.13011152,
@@ -5416,6 +5478,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Columbia": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 40.7960199,
@@ -5427,6 +5490,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Fulton": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 31.57894737,
@@ -5438,6 +5502,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Clarion": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 40.625,
@@ -5449,6 +5514,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Elk": {
+    "showName": false,
     "outlier": true,
     "bailRate": {
       "black": 27.77777778,
@@ -5460,6 +5526,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Indiana": {
+    "showName": false,
     "outlier": false,
     "bailRate": {
       "black": 30.39215686,
@@ -5469,7 +5536,19 @@ export const RACE_SCATTER_PLOT = {
       "black": "$20,861",
       "white": "$15,479"
     }
-  }
+  },
+  "State Average": {
+    "showName": true,
+    "outlier": false,
+    "bailRate": {
+      "black": 54.7,
+      "white": 37
+    },
+    "bailAmount": {
+      "black": "$36,202",
+      "white": "$26,868"
+    }
+  },
 };
 
 export const BAIL_POSTING_DATA = [

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -4770,7 +4770,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Somerset": {
-    "showName": true,
+    "showName": false,
     "outlier": false,
     "x": {
       "black": 69.56521739,
@@ -4806,7 +4806,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Sullivan": {
-    "showName": true,
+    "showName": false,
     "outlier": true,
     "x": {
       "black": 62.5,
@@ -4818,7 +4818,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Wayne": {
-    "showName": true,
+    "showName": false,
     "outlier": false,
     "x": {
       "black": 64.86486486,
@@ -4830,7 +4830,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Blair": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 58.6998088,
@@ -4950,7 +4950,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Armstrong": {
-    "showName": true,
+    "showName": false,
     "outlier": false,
     "x": {
       "black": 62.71186441,
@@ -5010,7 +5010,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Allegheny": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 57.06645057,
@@ -5022,7 +5022,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Westmoreland": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 50.05045409,
@@ -5094,7 +5094,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Lackawanna": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 67.1345995,
@@ -5178,7 +5178,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Union": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 38.20224719,
@@ -5190,7 +5190,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Dauphin": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 51.21710526,
@@ -5202,7 +5202,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Montgomery": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 43.27198364,
@@ -5346,7 +5346,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Clinton": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 47.14285714,
@@ -5382,7 +5382,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Bucks": {
-    "showName": true,
+    "showName": false,
     "outlier": false,
     "x": {
       "black": 41.06901218,
@@ -5418,7 +5418,7 @@ export const RACE_SCATTER_PLOT = {
     }
   },
   "Berks": {
-    "showName": false,
+    "showName": true,
     "outlier": false,
     "x": {
       "black": 58.42078961,

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -4732,6 +4732,746 @@ export const BAIL_RACE_AMOUNT_DATA = [
   }
 ];
 
+export const RACE_SCATTER_PLOT = {
+  "Cameron": {
+    "outlier": true,
+    "bailRate": {
+      "black": 100,
+      "white": 25.45454545
+    },
+    "bailAmount": {
+      "black": "$10,000",
+      "white": "$26,481"
+    }
+  },
+  "Forest": {
+    "outlier": true,
+    "bailRate": {
+      "black": 85,
+      "white": 32.03883495
+    },
+    "bailAmount": {
+      "black": "$21,438",
+      "white": "$22,344"
+    }
+  },
+  "Potter": {
+    "outlier": true,
+    "bailRate": {
+      "black": 75,
+      "white": 23.24786325
+    },
+    "bailAmount": {
+      "black": "$15,700",
+      "white": "$19,338"
+    }
+  },
+  "Somerset": {
+    "outlier": false,
+    "bailRate": {
+      "black": 69.56521739,
+      "white": 23.20855615
+    },
+    "bailAmount": {
+      "black": "$78,071",
+      "white": "$33,896"
+    }
+  },
+  "Jefferson": {
+    "outlier": false,
+    "bailRate": {
+      "black": 72.97297297,
+      "white": 38.35252436
+    },
+    "bailAmount": {
+      "black": "$35,040",
+      "white": "$45,707"
+    }
+  },
+  "Warren": {
+    "outlier": true,
+    "bailRate": {
+      "black": 70,
+      "white": 39.95067818
+    },
+    "bailAmount": {
+      "black": "$32,692",
+      "white": "$25,369"
+    }
+  },
+  "Sullivan": {
+    "outlier": true,
+    "bailRate": {
+      "black": 62.5,
+      "white": 32.63157895
+    },
+    "bailAmount": {
+      "black": "$5,000",
+      "white": "$18,667"
+    }
+  },
+  "Wayne": {
+    "outlier": false,
+    "bailRate": {
+      "black": 64.86486486,
+      "white": 35.30997305
+    },
+    "bailAmount": {
+      "black": "$28,682",
+      "white": "$32,101"
+    }
+  },
+  "Blair": {
+    "outlier": false,
+    "bailRate": {
+      "black": 58.6998088,
+      "white": 31.76853358
+    },
+    "bailAmount": {
+      "black": "$43,726",
+      "white": "$29,256"
+    }
+  },
+  "Lycoming": {
+    "outlier": false,
+    "bailRate": {
+      "black": 55.01355014,
+      "white": 28.14726841
+    },
+    "bailAmount": {
+      "black": "$77,030",
+      "white": "$37,028"
+    }
+  },
+  "Susquehanna": {
+    "outlier": true,
+    "bailRate": {
+      "black": 66.66666667,
+      "white": 39.76377953
+    },
+    "bailAmount": {
+      "black": "$29,808",
+      "white": "$27,138"
+    }
+  },
+  "Erie": {
+    "outlier": false,
+    "bailRate": {
+      "black": 63.73239437,
+      "white": 37.02714731
+    },
+    "bailAmount": {
+      "black": "$38,881",
+      "white": "$23,611"
+    }
+  },
+  "Cambria": {
+    "outlier": false,
+    "bailRate": {
+      "black": 65.52083333,
+      "white": 39.14590747
+    },
+    "bailAmount": {
+      "black": "$51,483",
+      "white": "$28,879"
+    }
+  },
+  "Huntingdon": {
+    "outlier": false,
+    "bailRate": {
+      "black": 64.05228758,
+      "white": 37.83333333
+    },
+    "bailAmount": {
+      "black": "$22,010",
+      "white": "$18,028"
+    }
+  },
+  "Crawford": {
+    "outlier": false,
+    "bailRate": {
+      "black": 53.33333333,
+      "white": 28.3197832
+    },
+    "bailAmount": {
+      "black": "$32,600",
+      "white": "$21,505"
+    }
+  },
+  "Centre": {
+    "outlier": false,
+    "bailRate": {
+      "black": 46.74115456,
+      "white": 21.88492764
+    },
+    "bailAmount": {
+      "black": "$45,976",
+      "white": "$34,614"
+    }
+  },
+  "Venango": {
+    "outlier": false,
+    "bailRate": {
+      "black": 60.13986014,
+      "white": 35.56187767
+    },
+    "bailAmount": {
+      "black": "$48,712",
+      "white": "$35,510"
+    }
+  },
+  "Clearfield": {
+    "outlier": false,
+    "bailRate": {
+      "black": 59.30232558,
+      "white": 35.64718163
+    },
+    "bailAmount": {
+      "black": "$43,890",
+      "white": "$23,215"
+    }
+  },
+  "Armstrong": {
+    "outlier": false,
+    "bailRate": {
+      "black": 62.71186441,
+      "white": 39.52662722
+    },
+    "bailAmount": {
+      "black": "$18,541",
+      "white": "$13,560"
+    }
+  },
+  "Northumberland": {
+    "outlier": false,
+    "bailRate": {
+      "black": 56.81818182,
+      "white": 33.91066545
+    },
+    "bailAmount": {
+      "black": "$63,255",
+      "white": "$38,641"
+    }
+  },
+  "Lawrence": {
+    "outlier": false,
+    "bailRate": {
+      "black": 66.28477905,
+      "white": 43.4806939
+    },
+    "bailAmount": {
+      "black": "$25,778",
+      "white": "$15,192"
+    }
+  },
+  "Mifflin": {
+    "outlier": false,
+    "bailRate": {
+      "black": 70.11494253,
+      "white": 47.48201439
+    },
+    "bailAmount": {
+      "black": "$52,219",
+      "white": "$35,331"
+    }
+  },
+  "Tioga": {
+    "outlier": false,
+    "bailRate": {
+      "black": 57,
+      "white": 34.50800915
+    },
+    "bailAmount": {
+      "black": "$30,455",
+      "white": "$18,916"
+    }
+  },
+  "Allegheny": {
+    "outlier": false,
+    "bailRate": {
+      "black": 57.06645057,
+      "white": 35.29897333
+    },
+    "bailAmount": {
+      "black": "$21,080",
+      "white": "$15,881"
+    }
+  },
+  "Westmoreland": {
+    "outlier": false,
+    "bailRate": {
+      "black": 50.05045409,
+      "white": 28.61736334
+    },
+    "bailAmount": {
+      "black": "$30,920",
+      "white": "$17,072"
+    }
+  },
+  "Greene": {
+    "outlier": false,
+    "bailRate": {
+      "black": 58.97435897,
+      "white": 37.86163522
+    },
+    "bailAmount": {
+      "black": "$20,977",
+      "white": "$15,107"
+    }
+  },
+  "Beaver": {
+    "outlier": false,
+    "bailRate": {
+      "black": 64.33048433,
+      "white": 43.92212726
+    },
+    "bailAmount": {
+      "black": "$26,145",
+      "white": "$13,733"
+    }
+  },
+  "McKean": {
+    "outlier": false,
+    "bailRate": {
+      "black": 61.33333333,
+      "white": 41.23134328
+    },
+    "bailAmount": {
+      "black": "$34,911",
+      "white": "$23,475"
+    }
+  },
+  "Washington": {
+    "outlier": false,
+    "bailRate": {
+      "black": 55.77092511,
+      "white": 35.82116788
+    },
+    "bailAmount": {
+      "black": "$33,527",
+      "white": "$19,878"
+    }
+  },
+  "Luzerne": {
+    "outlier": false,
+    "bailRate": {
+      "black": 53.5892323,
+      "white": 34.6550856
+    },
+    "bailAmount": {
+      "black": "$47,113",
+      "white": "$32,968"
+    }
+  },
+  "Lackawanna": {
+    "outlier": false,
+    "bailRate": {
+      "black": 67.1345995,
+      "white": 48.9720035
+    },
+    "bailAmount": {
+      "black": "$41,104",
+      "white": "$26,940"
+    }
+  },
+  "Snyder": {
+    "outlier": false,
+    "bailRate": {
+      "black": 52.5,
+      "white": 34.59183673
+    },
+    "bailAmount": {
+      "black": "$29,659",
+      "white": "$27,551"
+    }
+  },
+  "Bradford": {
+    "outlier": false,
+    "bailRate": {
+      "black": 62.26415094,
+      "white": 45.14840183
+    },
+    "bailAmount": {
+      "black": "$63,125",
+      "white": "$32,077"
+    }
+  },
+  "Cumberland": {
+    "outlier": false,
+    "bailRate": {
+      "black": 51.61744023,
+      "white": 35.0094162
+    },
+    "bailAmount": {
+      "black": "$34,037",
+      "white": "$23,281"
+    }
+  },
+  "Butler": {
+    "outlier": false,
+    "bailRate": {
+      "black": 44.7761194,
+      "white": 29.5154185
+    },
+    "bailAmount": {
+      "black": "$42,155",
+      "white": "$12,248"
+    }
+  },
+  "Delaware": {
+    "outlier": false,
+    "bailRate": {
+      "black": 63.75237882,
+      "white": 48.4952381
+    },
+    "bailAmount": {
+      "black": "$43,250",
+      "white": "$31,974"
+    }
+  },
+  "Bedford": {
+    "outlier": false,
+    "bailRate": {
+      "black": 52.57731959,
+      "white": 37.56419663
+    },
+    "bailAmount": {
+      "black": "$65,010",
+      "white": "$49,176"
+    }
+  },
+  "Union": {
+    "outlier": false,
+    "bailRate": {
+      "black": 38.20224719,
+      "white": 23.24159021
+    },
+    "bailAmount": {
+      "black": "$34,667",
+      "white": "$25,807"
+    }
+  },
+  "Dauphin": {
+    "outlier": false,
+    "bailRate": {
+      "black": 51.21710526,
+      "white": 36.4556962
+    },
+    "bailAmount": {
+      "black": "$40,031",
+      "white": "$32,313"
+    }
+  },
+  "Montgomery": {
+    "outlier": false,
+    "bailRate": {
+      "black": 43.27198364,
+      "white": 28.69733969
+    },
+    "bailAmount": {
+      "black": "$29,169",
+      "white": "$21,885"
+    }
+  },
+  "Adams": {
+    "outlier": false,
+    "bailRate": {
+      "black": 43.56060606,
+      "white": 29.03651562
+    },
+    "bailAmount": {
+      "black": "$29,479",
+      "white": "$26,077"
+    }
+  },
+  "Chester": {
+    "outlier": false,
+    "bailRate": {
+      "black": 48.47354138,
+      "white": 34.29690666
+    },
+    "bailAmount": {
+      "black": "$32,205",
+      "white": "$22,836"
+    }
+  },
+  "Franklin": {
+    "outlier": false,
+    "bailRate": {
+      "black": 49.26553672,
+      "white": 35.19494204
+    },
+    "bailAmount": {
+      "black": "$61,407",
+      "white": "$50,242"
+    }
+  },
+  "York": {
+    "outlier": false,
+    "bailRate": {
+      "black": 54.11985019,
+      "white": 41.11844787
+    },
+    "bailAmount": {
+      "black": "$30,258",
+      "white": "$18,416"
+    }
+  },
+  "Philadelphia": {
+    "outlier": false,
+    "bailRate": {
+      "black": 56.02170568,
+      "white": 43.3107617
+    },
+    "bailAmount": {
+      "black": "$54,302",
+      "white": "$43,459"
+    }
+  },
+  "Lancaster": {
+    "outlier": false,
+    "bailRate": {
+      "black": 55.54532904,
+      "white": 43.07425541
+    },
+    "bailAmount": {
+      "black": "$57,668",
+      "white": "$48,383"
+    }
+  },
+  "Perry": {
+    "outlier": false,
+    "bailRate": {
+      "black": 40,
+      "white": 27.68130746
+    },
+    "bailAmount": {
+      "black": "$41,126",
+      "white": "$24,007"
+    }
+  },
+  "Mercer": {
+    "outlier": false,
+    "bailRate": {
+      "black": 45.40337711,
+      "white": 33.35235378
+    },
+    "bailAmount": {
+      "black": "$29,504",
+      "white": "$23,005"
+    }
+  },
+  "Northampton": {
+    "outlier": false,
+    "bailRate": {
+      "black": 55.7063541,
+      "white": 43.86813852
+    },
+    "bailAmount": {
+      "black": "$34,972",
+      "white": "$24,095"
+    }
+  },
+  "Fayette": {
+    "outlier": false,
+    "bailRate": {
+      "black": 54,
+      "white": 42.30092389
+    },
+    "bailAmount": {
+      "black": "$25,444",
+      "white": "$17,203"
+    }
+  },
+  "Carbon": {
+    "outlier": false,
+    "bailRate": {
+      "black": 43.7751004,
+      "white": 32.34139961
+    },
+    "bailAmount": {
+      "black": "$35,236",
+      "white": "$24,452"
+    }
+  },
+  "Clinton": {
+    "outlier": false,
+    "bailRate": {
+      "black": 47.14285714,
+      "white": 35.98750976
+    },
+    "bailAmount": {
+      "black": "$29,609",
+      "white": "$19,817"
+    }
+  },
+  "Lebanon": {
+    "outlier": false,
+    "bailRate": {
+      "black": 48.84547069,
+      "white": 37.97733949
+    },
+    "bailAmount": {
+      "black": "$36,343",
+      "white": "$23,902"
+    }
+  },
+  "Montour": {
+    "outlier": true,
+    "bailRate": {
+      "black": 46.15384615,
+      "white": 35.34136546
+    },
+    "bailAmount": {
+      "black": "$25,556",
+      "white": "$27,449"
+    }
+  },
+  "Bucks": {
+    "outlier": false,
+    "bailRate": {
+      "black": 41.06901218,
+      "white": 30.62392673
+    },
+    "bailAmount": {
+      "black": "$73,635",
+      "white": "$58,683"
+    }
+  },
+  "Schuylkill": {
+    "outlier": false,
+    "bailRate": {
+      "black": 46.5060241,
+      "white": 37.27521501
+    },
+    "bailAmount": {
+      "black": "$28,947",
+      "white": "$19,996"
+    }
+  },
+  "Lehigh": {
+    "outlier": false,
+    "bailRate": {
+      "black": 61.81634031,
+      "white": 52.85376562
+    },
+    "bailAmount": {
+      "black": "$25,138",
+      "white": "$16,341"
+    }
+  },
+  "Berks": {
+    "outlier": false,
+    "bailRate": {
+      "black": 58.42078961,
+      "white": 50.24259317
+    },
+    "bailAmount": {
+      "black": "$35,039",
+      "white": "$27,399"
+    }
+  },
+  "Juniata": {
+    "outlier": true,
+    "bailRate": {
+      "black": 43.75,
+      "white": 36.67425968
+    },
+    "bailAmount": {
+      "black": "$29,167",
+      "white": "$22,330"
+    }
+  },
+  "Wyoming": {
+    "outlier": true,
+    "bailRate": {
+      "black": 40,
+      "white": 35.59650824
+    },
+    "bailAmount": {
+      "black": "$22,611",
+      "white": "$25,042"
+    }
+  },
+  "Pike": {
+    "outlier": false,
+    "bailRate": {
+      "black": 37.41007194,
+      "white": 34.02061856
+    },
+    "bailAmount": {
+      "black": "$34,755",
+      "white": "$21,534"
+    }
+  },
+  "Monroe": {
+    "outlier": false,
+    "bailRate": {
+      "black": 35.13011152,
+      "white": 32.41612358
+    },
+    "bailAmount": {
+      "black": "$34,085",
+      "white": "$21,495"
+    }
+  },
+  "Columbia": {
+    "outlier": false,
+    "bailRate": {
+      "black": 40.7960199,
+      "white": 38.46153846
+    },
+    "bailAmount": {
+      "black": "$57,747",
+      "white": "$33,130"
+    }
+  },
+  "Fulton": {
+    "outlier": false,
+    "bailRate": {
+      "black": 31.57894737,
+      "white": 29.27536232
+    },
+    "bailAmount": {
+      "black": "$24,000",
+      "white": "$57,879"
+    }
+  },
+  "Clarion": {
+    "outlier": false,
+    "bailRate": {
+      "black": 40.625,
+      "white": 40.83259522
+    },
+    "bailAmount": {
+      "black": "$14,200",
+      "white": "$20,698"
+    }
+  },
+  "Elk": {
+    "outlier": true,
+    "bailRate": {
+      "black": 27.77777778,
+      "white": 28.68117798
+    },
+    "bailAmount": {
+      "black": "$14,375",
+      "white": "$21,093"
+    }
+  },
+  "Indiana": {
+    "outlier": false,
+    "bailRate": {
+      "black": 30.39215686,
+      "white": 36.21169916
+    },
+    "bailAmount": {
+      "black": "$20,861",
+      "white": "$15,479"
+    }
+  }
+};
+
 export const BAIL_POSTING_DATA = [
   {
     "data": [

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -4736,11 +4736,11 @@ export const RACE_SCATTER_PLOT = {
   "Cameron": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 100,
       "white": 25.45454545
     },
-    "bailAmount": {
+    "y": {
       "black": "$10,000",
       "white": "$26,481"
     }
@@ -4748,11 +4748,11 @@ export const RACE_SCATTER_PLOT = {
   "Forest": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 85,
       "white": 32.03883495
     },
-    "bailAmount": {
+    "y": {
       "black": "$21,438",
       "white": "$22,344"
     }
@@ -4760,11 +4760,11 @@ export const RACE_SCATTER_PLOT = {
   "Potter": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 75,
       "white": 23.24786325
     },
-    "bailAmount": {
+    "y": {
       "black": "$15,700",
       "white": "$19,338"
     }
@@ -4772,11 +4772,11 @@ export const RACE_SCATTER_PLOT = {
   "Somerset": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 69.56521739,
       "white": 23.20855615
     },
-    "bailAmount": {
+    "y": {
       "black": "$78,071",
       "white": "$33,896"
     }
@@ -4784,11 +4784,11 @@ export const RACE_SCATTER_PLOT = {
   "Jefferson": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 72.97297297,
       "white": 38.35252436
     },
-    "bailAmount": {
+    "y": {
       "black": "$35,040",
       "white": "$45,707"
     }
@@ -4796,11 +4796,11 @@ export const RACE_SCATTER_PLOT = {
   "Warren": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 70,
       "white": 39.95067818
     },
-    "bailAmount": {
+    "y": {
       "black": "$32,692",
       "white": "$25,369"
     }
@@ -4808,11 +4808,11 @@ export const RACE_SCATTER_PLOT = {
   "Sullivan": {
     "showName": true,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 62.5,
       "white": 32.63157895
     },
-    "bailAmount": {
+    "y": {
       "black": "$5,000",
       "white": "$18,667"
     }
@@ -4820,11 +4820,11 @@ export const RACE_SCATTER_PLOT = {
   "Wayne": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 64.86486486,
       "white": 35.30997305
     },
-    "bailAmount": {
+    "y": {
       "black": "$28,682",
       "white": "$32,101"
     }
@@ -4832,11 +4832,11 @@ export const RACE_SCATTER_PLOT = {
   "Blair": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 58.6998088,
       "white": 31.76853358
     },
-    "bailAmount": {
+    "y": {
       "black": "$43,726",
       "white": "$29,256"
     }
@@ -4844,11 +4844,11 @@ export const RACE_SCATTER_PLOT = {
   "Lycoming": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 55.01355014,
       "white": 28.14726841
     },
-    "bailAmount": {
+    "y": {
       "black": "$77,030",
       "white": "$37,028"
     }
@@ -4856,11 +4856,11 @@ export const RACE_SCATTER_PLOT = {
   "Susquehanna": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 66.66666667,
       "white": 39.76377953
     },
-    "bailAmount": {
+    "y": {
       "black": "$29,808",
       "white": "$27,138"
     }
@@ -4868,11 +4868,11 @@ export const RACE_SCATTER_PLOT = {
   "Erie": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 63.73239437,
       "white": 37.02714731
     },
-    "bailAmount": {
+    "y": {
       "black": "$38,881",
       "white": "$23,611"
     }
@@ -4880,11 +4880,11 @@ export const RACE_SCATTER_PLOT = {
   "Cambria": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 65.52083333,
       "white": 39.14590747
     },
-    "bailAmount": {
+    "y": {
       "black": "$51,483",
       "white": "$28,879"
     }
@@ -4892,11 +4892,11 @@ export const RACE_SCATTER_PLOT = {
   "Huntingdon": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 64.05228758,
       "white": 37.83333333
     },
-    "bailAmount": {
+    "y": {
       "black": "$22,010",
       "white": "$18,028"
     }
@@ -4904,11 +4904,11 @@ export const RACE_SCATTER_PLOT = {
   "Crawford": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 53.33333333,
       "white": 28.3197832
     },
-    "bailAmount": {
+    "y": {
       "black": "$32,600",
       "white": "$21,505"
     }
@@ -4916,11 +4916,11 @@ export const RACE_SCATTER_PLOT = {
   "Centre": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 46.74115456,
       "white": 21.88492764
     },
-    "bailAmount": {
+    "y": {
       "black": "$45,976",
       "white": "$34,614"
     }
@@ -4928,11 +4928,11 @@ export const RACE_SCATTER_PLOT = {
   "Venango": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 60.13986014,
       "white": 35.56187767
     },
-    "bailAmount": {
+    "y": {
       "black": "$48,712",
       "white": "$35,510"
     }
@@ -4940,11 +4940,11 @@ export const RACE_SCATTER_PLOT = {
   "Clearfield": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 59.30232558,
       "white": 35.64718163
     },
-    "bailAmount": {
+    "y": {
       "black": "$43,890",
       "white": "$23,215"
     }
@@ -4952,11 +4952,11 @@ export const RACE_SCATTER_PLOT = {
   "Armstrong": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 62.71186441,
       "white": 39.52662722
     },
-    "bailAmount": {
+    "y": {
       "black": "$18,541",
       "white": "$13,560"
     }
@@ -4964,11 +4964,11 @@ export const RACE_SCATTER_PLOT = {
   "Northumberland": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 56.81818182,
       "white": 33.91066545
     },
-    "bailAmount": {
+    "y": {
       "black": "$63,255",
       "white": "$38,641"
     }
@@ -4976,11 +4976,11 @@ export const RACE_SCATTER_PLOT = {
   "Lawrence": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 66.28477905,
       "white": 43.4806939
     },
-    "bailAmount": {
+    "y": {
       "black": "$25,778",
       "white": "$15,192"
     }
@@ -4988,11 +4988,11 @@ export const RACE_SCATTER_PLOT = {
   "Mifflin": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 70.11494253,
       "white": 47.48201439
     },
-    "bailAmount": {
+    "y": {
       "black": "$52,219",
       "white": "$35,331"
     }
@@ -5000,11 +5000,11 @@ export const RACE_SCATTER_PLOT = {
   "Tioga": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 57,
       "white": 34.50800915
     },
-    "bailAmount": {
+    "y": {
       "black": "$30,455",
       "white": "$18,916"
     }
@@ -5012,11 +5012,11 @@ export const RACE_SCATTER_PLOT = {
   "Allegheny": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 57.06645057,
       "white": 35.29897333
     },
-    "bailAmount": {
+    "y": {
       "black": "$21,080",
       "white": "$15,881"
     }
@@ -5024,11 +5024,11 @@ export const RACE_SCATTER_PLOT = {
   "Westmoreland": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 50.05045409,
       "white": 28.61736334
     },
-    "bailAmount": {
+    "y": {
       "black": "$30,920",
       "white": "$17,072"
     }
@@ -5036,11 +5036,11 @@ export const RACE_SCATTER_PLOT = {
   "Greene": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 58.97435897,
       "white": 37.86163522
     },
-    "bailAmount": {
+    "y": {
       "black": "$20,977",
       "white": "$15,107"
     }
@@ -5048,11 +5048,11 @@ export const RACE_SCATTER_PLOT = {
   "Beaver": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 64.33048433,
       "white": 43.92212726
     },
-    "bailAmount": {
+    "y": {
       "black": "$26,145",
       "white": "$13,733"
     }
@@ -5060,11 +5060,11 @@ export const RACE_SCATTER_PLOT = {
   "McKean": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 61.33333333,
       "white": 41.23134328
     },
-    "bailAmount": {
+    "y": {
       "black": "$34,911",
       "white": "$23,475"
     }
@@ -5072,11 +5072,11 @@ export const RACE_SCATTER_PLOT = {
   "Washington": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 55.77092511,
       "white": 35.82116788
     },
-    "bailAmount": {
+    "y": {
       "black": "$33,527",
       "white": "$19,878"
     }
@@ -5084,11 +5084,11 @@ export const RACE_SCATTER_PLOT = {
   "Luzerne": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 53.5892323,
       "white": 34.6550856
     },
-    "bailAmount": {
+    "y": {
       "black": "$47,113",
       "white": "$32,968"
     }
@@ -5096,11 +5096,11 @@ export const RACE_SCATTER_PLOT = {
   "Lackawanna": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 67.1345995,
       "white": 48.9720035
     },
-    "bailAmount": {
+    "y": {
       "black": "$41,104",
       "white": "$26,940"
     }
@@ -5108,11 +5108,11 @@ export const RACE_SCATTER_PLOT = {
   "Snyder": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 52.5,
       "white": 34.59183673
     },
-    "bailAmount": {
+    "y": {
       "black": "$29,659",
       "white": "$27,551"
     }
@@ -5120,11 +5120,11 @@ export const RACE_SCATTER_PLOT = {
   "Bradford": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 62.26415094,
       "white": 45.14840183
     },
-    "bailAmount": {
+    "y": {
       "black": "$63,125",
       "white": "$32,077"
     }
@@ -5132,11 +5132,11 @@ export const RACE_SCATTER_PLOT = {
   "Cumberland": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 51.61744023,
       "white": 35.0094162
     },
-    "bailAmount": {
+    "y": {
       "black": "$34,037",
       "white": "$23,281"
     }
@@ -5144,11 +5144,11 @@ export const RACE_SCATTER_PLOT = {
   "Butler": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 44.7761194,
       "white": 29.5154185
     },
-    "bailAmount": {
+    "y": {
       "black": "$42,155",
       "white": "$12,248"
     }
@@ -5156,11 +5156,11 @@ export const RACE_SCATTER_PLOT = {
   "Delaware": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 63.75237882,
       "white": 48.4952381
     },
-    "bailAmount": {
+    "y": {
       "black": "$43,250",
       "white": "$31,974"
     }
@@ -5168,11 +5168,11 @@ export const RACE_SCATTER_PLOT = {
   "Bedford": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 52.57731959,
       "white": 37.56419663
     },
-    "bailAmount": {
+    "y": {
       "black": "$65,010",
       "white": "$49,176"
     }
@@ -5180,11 +5180,11 @@ export const RACE_SCATTER_PLOT = {
   "Union": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 38.20224719,
       "white": 23.24159021
     },
-    "bailAmount": {
+    "y": {
       "black": "$34,667",
       "white": "$25,807"
     }
@@ -5192,11 +5192,11 @@ export const RACE_SCATTER_PLOT = {
   "Dauphin": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 51.21710526,
       "white": 36.4556962
     },
-    "bailAmount": {
+    "y": {
       "black": "$40,031",
       "white": "$32,313"
     }
@@ -5204,11 +5204,11 @@ export const RACE_SCATTER_PLOT = {
   "Montgomery": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 43.27198364,
       "white": 28.69733969
     },
-    "bailAmount": {
+    "y": {
       "black": "$29,169",
       "white": "$21,885"
     }
@@ -5216,11 +5216,11 @@ export const RACE_SCATTER_PLOT = {
   "Adams": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 43.56060606,
       "white": 29.03651562
     },
-    "bailAmount": {
+    "y": {
       "black": "$29,479",
       "white": "$26,077"
     }
@@ -5228,11 +5228,11 @@ export const RACE_SCATTER_PLOT = {
   "Chester": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 48.47354138,
       "white": 34.29690666
     },
-    "bailAmount": {
+    "y": {
       "black": "$32,205",
       "white": "$22,836"
     }
@@ -5240,11 +5240,11 @@ export const RACE_SCATTER_PLOT = {
   "Franklin": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 49.26553672,
       "white": 35.19494204
     },
-    "bailAmount": {
+    "y": {
       "black": "$61,407",
       "white": "$50,242"
     }
@@ -5252,11 +5252,11 @@ export const RACE_SCATTER_PLOT = {
   "York": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 54.11985019,
       "white": 41.11844787
     },
-    "bailAmount": {
+    "y": {
       "black": "$30,258",
       "white": "$18,416"
     }
@@ -5264,11 +5264,11 @@ export const RACE_SCATTER_PLOT = {
   "Philadelphia": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 56.02170568,
       "white": 43.3107617
     },
-    "bailAmount": {
+    "y": {
       "black": "$54,302",
       "white": "$43,459"
     }
@@ -5276,11 +5276,11 @@ export const RACE_SCATTER_PLOT = {
   "Lancaster": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 55.54532904,
       "white": 43.07425541
     },
-    "bailAmount": {
+    "y": {
       "black": "$57,668",
       "white": "$48,383"
     }
@@ -5288,11 +5288,11 @@ export const RACE_SCATTER_PLOT = {
   "Perry": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 40,
       "white": 27.68130746
     },
-    "bailAmount": {
+    "y": {
       "black": "$41,126",
       "white": "$24,007"
     }
@@ -5300,11 +5300,11 @@ export const RACE_SCATTER_PLOT = {
   "Mercer": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 45.40337711,
       "white": 33.35235378
     },
-    "bailAmount": {
+    "y": {
       "black": "$29,504",
       "white": "$23,005"
     }
@@ -5312,11 +5312,11 @@ export const RACE_SCATTER_PLOT = {
   "Northampton": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 55.7063541,
       "white": 43.86813852
     },
-    "bailAmount": {
+    "y": {
       "black": "$34,972",
       "white": "$24,095"
     }
@@ -5324,11 +5324,11 @@ export const RACE_SCATTER_PLOT = {
   "Fayette": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 54,
       "white": 42.30092389
     },
-    "bailAmount": {
+    "y": {
       "black": "$25,444",
       "white": "$17,203"
     }
@@ -5336,11 +5336,11 @@ export const RACE_SCATTER_PLOT = {
   "Carbon": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 43.7751004,
       "white": 32.34139961
     },
-    "bailAmount": {
+    "y": {
       "black": "$35,236",
       "white": "$24,452"
     }
@@ -5348,11 +5348,11 @@ export const RACE_SCATTER_PLOT = {
   "Clinton": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 47.14285714,
       "white": 35.98750976
     },
-    "bailAmount": {
+    "y": {
       "black": "$29,609",
       "white": "$19,817"
     }
@@ -5360,11 +5360,11 @@ export const RACE_SCATTER_PLOT = {
   "Lebanon": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 48.84547069,
       "white": 37.97733949
     },
-    "bailAmount": {
+    "y": {
       "black": "$36,343",
       "white": "$23,902"
     }
@@ -5372,11 +5372,11 @@ export const RACE_SCATTER_PLOT = {
   "Montour": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 46.15384615,
       "white": 35.34136546
     },
-    "bailAmount": {
+    "y": {
       "black": "$25,556",
       "white": "$27,449"
     }
@@ -5384,11 +5384,11 @@ export const RACE_SCATTER_PLOT = {
   "Bucks": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 41.06901218,
       "white": 30.62392673
     },
-    "bailAmount": {
+    "y": {
       "black": "$73,635",
       "white": "$58,683"
     }
@@ -5396,11 +5396,11 @@ export const RACE_SCATTER_PLOT = {
   "Schuylkill": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 46.5060241,
       "white": 37.27521501
     },
-    "bailAmount": {
+    "y": {
       "black": "$28,947",
       "white": "$19,996"
     }
@@ -5408,11 +5408,11 @@ export const RACE_SCATTER_PLOT = {
   "Lehigh": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 61.81634031,
       "white": 52.85376562
     },
-    "bailAmount": {
+    "y": {
       "black": "$25,138",
       "white": "$16,341"
     }
@@ -5420,11 +5420,11 @@ export const RACE_SCATTER_PLOT = {
   "Berks": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 58.42078961,
       "white": 50.24259317
     },
-    "bailAmount": {
+    "y": {
       "black": "$35,039",
       "white": "$27,399"
     }
@@ -5432,11 +5432,11 @@ export const RACE_SCATTER_PLOT = {
   "Juniata": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 43.75,
       "white": 36.67425968
     },
-    "bailAmount": {
+    "y": {
       "black": "$29,167",
       "white": "$22,330"
     }
@@ -5444,11 +5444,11 @@ export const RACE_SCATTER_PLOT = {
   "Wyoming": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 40,
       "white": 35.59650824
     },
-    "bailAmount": {
+    "y": {
       "black": "$22,611",
       "white": "$25,042"
     }
@@ -5456,11 +5456,11 @@ export const RACE_SCATTER_PLOT = {
   "Pike": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 37.41007194,
       "white": 34.02061856
     },
-    "bailAmount": {
+    "y": {
       "black": "$34,755",
       "white": "$21,534"
     }
@@ -5468,11 +5468,11 @@ export const RACE_SCATTER_PLOT = {
   "Monroe": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 35.13011152,
       "white": 32.41612358
     },
-    "bailAmount": {
+    "y": {
       "black": "$34,085",
       "white": "$21,495"
     }
@@ -5480,11 +5480,11 @@ export const RACE_SCATTER_PLOT = {
   "Columbia": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 40.7960199,
       "white": 38.46153846
     },
-    "bailAmount": {
+    "y": {
       "black": "$57,747",
       "white": "$33,130"
     }
@@ -5492,11 +5492,11 @@ export const RACE_SCATTER_PLOT = {
   "Fulton": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 31.57894737,
       "white": 29.27536232
     },
-    "bailAmount": {
+    "y": {
       "black": "$24,000",
       "white": "$57,879"
     }
@@ -5504,11 +5504,11 @@ export const RACE_SCATTER_PLOT = {
   "Clarion": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 40.625,
       "white": 40.83259522
     },
-    "bailAmount": {
+    "y": {
       "black": "$14,200",
       "white": "$20,698"
     }
@@ -5516,11 +5516,11 @@ export const RACE_SCATTER_PLOT = {
   "Elk": {
     "showName": false,
     "outlier": true,
-    "bailRate": {
+    "x": {
       "black": 27.77777778,
       "white": 28.68117798
     },
-    "bailAmount": {
+    "y": {
       "black": "$14,375",
       "white": "$21,093"
     }
@@ -5528,11 +5528,11 @@ export const RACE_SCATTER_PLOT = {
   "Indiana": {
     "showName": false,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 30.39215686,
       "white": 36.21169916
     },
-    "bailAmount": {
+    "y": {
       "black": "$20,861",
       "white": "$15,479"
     }
@@ -5540,11 +5540,11 @@ export const RACE_SCATTER_PLOT = {
   "State Average": {
     "showName": true,
     "outlier": false,
-    "bailRate": {
+    "x": {
       "black": 54.7,
       "white": 37
     },
-    "bailAmount": {
+    "y": {
       "black": "$36,202",
       "white": "$26,868"
     }

--- a/src/js/scatter-plot.js
+++ b/src/js/scatter-plot.js
@@ -1,0 +1,25 @@
+import { ScatterPlot } from "./classes/Graph.js";
+import { RACE_SCATTER_PLOT } from "./data.js";
+
+/* PLOT CREATION FUNCTIONS */
+const createRaceScatterPlot = () => {
+  const xAxis = {
+    name: "Cash Bail Rate",
+    min: 0,
+    max: 100
+  };
+  const yAxis = {
+    name: "Bail Amount",
+    min: 0,
+    max: 80000
+  };
+
+  const container = document.getElementById("race-scatter-plot");
+  return new ScatterPlot(RACE_SCATTER_PLOT, xAxis, yAxis, container);
+};
+
+// for converting dollar strings to numbers:
+// Number(value.replace(/[^\d.-]/g, ""))
+
+/* RENDER PAGE */
+createRaceScatterPlot();

--- a/src/js/scatter-plot.js
+++ b/src/js/scatter-plot.js
@@ -8,15 +8,14 @@ const createRaceScatterPlot = () => {
     min: 20,
     max: 100,
     numTicks: 8,
-    unit: "%"
+    convert: num => `${num}%`
   };
   const yAxis = {
     name: "Bail Amount",
     min: 0,
     max: 80000,
     numTicks: 8,
-    transformFunc: num => num / 1000,
-    unit: "K"
+    convert: num => num === 0 ? "0" : `${num / 1000}K`
   };
 
   const container = document.getElementById("race-scatter-plot");

--- a/src/js/scatter-plot.js
+++ b/src/js/scatter-plot.js
@@ -5,13 +5,18 @@ import { RACE_SCATTER_PLOT } from "./data.js";
 const createRaceScatterPlot = () => {
   const xAxis = {
     name: "Cash Bail Rate",
-    min: 0,
-    max: 100
+    min: 20,
+    max: 100,
+    numTicks: 8,
+    unit: "%"
   };
   const yAxis = {
     name: "Bail Amount",
     min: 0,
-    max: 80000
+    max: 80000,
+    numTicks: 8,
+    transformFunc: num => num / 1000,
+    unit: "K"
   };
 
   const container = document.getElementById("race-scatter-plot");

--- a/src/js/scatter-plot.js
+++ b/src/js/scatter-plot.js
@@ -18,8 +18,5 @@ const createRaceScatterPlot = () => {
   return new ScatterPlot(RACE_SCATTER_PLOT, xAxis, yAxis, container);
 };
 
-// for converting dollar strings to numbers:
-// Number(value.replace(/[^\d.-]/g, ""))
-
 /* RENDER PAGE */
 createRaceScatterPlot();

--- a/src/js/scatter-plot.js
+++ b/src/js/scatter-plot.js
@@ -6,8 +6,8 @@ const createRaceScatterPlot = () => {
   const xAxis = {
     name: "Cash Bail Rate",
     min: 20,
-    max: 100,
-    numTicks: 8,
+    max: 80,
+    numTicks: 6,
     convert: num => `${num}%`
   };
   const yAxis = {

--- a/src/js/scatter-plot.js
+++ b/src/js/scatter-plot.js
@@ -8,8 +8,7 @@ const createRaceScatterPlot = () => {
     min: 20,
     max: 100,
     numTicks: 8,
-    convert: num => `${num}%`,
-    unit: "%"
+    convert: num => `${num}%`
   };
   const yAxis = {
     name: "Bail Amount",
@@ -18,9 +17,15 @@ const createRaceScatterPlot = () => {
     numTicks: 8,
     convert: num => num === 0 ? "0" : `${num / 1000}K`
   };
+  const toText = {
+    xHeader: "% Cash Bail",
+    yHeader: "Avg. Bail Amount",
+    x: value => `${value.toFixed(1)}%`,
+    y: value => value
+  };
 
   const container = document.getElementById("race-scatter-plot");
-  return new ScatterPlot(RACE_SCATTER_PLOT, xAxis, yAxis, container);
+  return new ScatterPlot(RACE_SCATTER_PLOT, xAxis, yAxis, toText, container);
 };
 
 /* RENDER PAGE */

--- a/src/js/scatter-plot.js
+++ b/src/js/scatter-plot.js
@@ -8,7 +8,8 @@ const createRaceScatterPlot = () => {
     min: 20,
     max: 100,
     numTicks: 8,
-    convert: num => `${num}%`
+    convert: num => `${num}%`,
+    unit: "%"
   };
   const yAxis = {
     name: "Bail Amount",


### PR DESCRIPTION
Changes discussed with Rong:
- ~Show search bar on both mobile and desktop for ease of finding counties~
  - Not exactly sure what we want to do when a county is searched; currently am just highlighting it (hover motion minus the tooltip) but will need Rong's input
- ~Add all county names from design; we can discuss with Jess to remove some if need be~
- ~For now do 50% opacity on outliers; Rong is going to experiment a bit and see if she can find a better option~
- ~Remove outliers button on mobile and just show them by default~
- ~Just show one axis label on mobile to avoid overlapping~
- ~Make plot smaller to handle phone sizes like iPhone SE~
  - Rong will ask Jess for which county labels on mobile
- What do we want to do about the `hover` event on mobile? Obviously this doesn't exist, so for tooltips my best suggestion is to make it so it shows up when you tap on a point (or search) and we can add an `x` in the corner of the tooltip so users can close it.
  - Mostly use search but Mario's tooltip's in #39 to handle mobile taps
  - TODO: will implement once #39 is merged in