### PR TITLE
Scatter plot, search, and toggle fixes

### DIFF
--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -27,7 +27,6 @@
   position: relative;
   display: flex;
   justify-content: center;
-  margin-bottom: 50px;
 }
 
 svg.scatter-plot {
@@ -37,7 +36,7 @@ svg.scatter-plot {
 .scatter-plot {
   width: 600px;
   height: 500px;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.075);
   overflow: visible;
 }
 

--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -60,7 +60,7 @@ svg.scatter-plot {
 }
 
 .scatter-plot-key span {
-  font-size: 11px;
+  font-size: 12px;
   line-height: 16px;
   color:rgba(255, 255, 255, 0.75);
 }
@@ -107,18 +107,18 @@ svg.scatter-plot {
 
 .axis-label {
   fill: #FFF;
-  font-size: 11px;
+  font-size: 12px;
   line-height: 13px;
   text-transform: uppercase;
 }
 
-.label-wrapper {
+svg.label-wrapper {
   overflow: visible;
 }
 
 .axis-tick {
   fill: rgba(255, 255, 255, 0.75);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 16px;
 }
 
@@ -182,7 +182,7 @@ svg.scatter-plot {
 
 .scatter-text {
   fill: #FFF;
-  font-size: 11px;
+  font-size: 12px;
   line-height: 16px;
   cursor: default;
 }

--- a/src/css/map.css
+++ b/src/css/map.css
@@ -72,6 +72,15 @@
   border: 1px #333 solid;
 }
 
+.switch.left {
+  border-radius: 3px 0 0 3px;
+}
+
+.switch.right {
+  border-radius: 0 3px 3px 0;
+  border-left: 0;
+}
+
 .switch-container .switch.showing, .switch-container .switch:hover {
   background-color: #1D1D1D;
 }

--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -57,6 +57,7 @@
 
   .bar-label {
     left: calc(100% + 0.5em);
+    font-size: 11px;
   }
 
   .total-budget-cell {
@@ -76,6 +77,10 @@
     padding: 10px;
   }
 
+  .btn-text {
+    font-size: 11px;
+  }
+
   .outliers-btn {
     display: none;
   }
@@ -88,6 +93,22 @@
 
   .map-row {
     flex-wrap: wrap;
+  }
+
+  .scatter-plot-key span {
+    font-size: 11px;
+  }
+
+  .axis-label {
+    font-size: 11px;
+  }
+
+  .axis-tick {
+    font-size: 11px;
+  }
+
+  .scatter-text {
+    font-size: 11px;
   }
 }
 

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -42,6 +42,7 @@
   padding: 10px 13px;
   color: #fff;
   font-size: 13px;
+  box-sizing: content-box;
 }
 
 /* Selection Label */
@@ -97,6 +98,7 @@ i.icon.delete:hover {
   background-color: #000;
   border-radius: 0 0 3px 3px;
   border-color: rgba(255, 255, 255, 0.4);
+  box-sizing: content-box;
 }
 
 .ui.selection.active.dropdown.upward .menu {
@@ -108,6 +110,7 @@ i.icon.delete:hover {
 }
 
 .ui.selection.dropdown .menu > .item {
+  margin-bottom: 0;
   padding-left: 13px;
   border-top: 0;
   color: #fff;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -50,7 +50,7 @@ body {
   color: #fff;
   font-family: "GT America Bold";
   font-weight: 600;
-  font-size: 11px;
+  font-size: 12px;
   text-align: center;
   border-radius: 3px;
 }

--- a/src/css/table.css
+++ b/src/css/table.css
@@ -174,6 +174,7 @@
 .switch-container .switch {
   width: 100px;
   padding: 10px;
+  text-transform: uppercase;
   border: 1px #333 solid;
 }
 

--- a/src/css/table.css
+++ b/src/css/table.css
@@ -35,6 +35,7 @@
 
 .table-container > table th.number-cell {
   text-align: right;
+  box-sizing: content-box;
 }
 
 .table-container > table th.retention-fee-cell {

--- a/src/css/visualization.css
+++ b/src/css/visualization.css
@@ -117,7 +117,7 @@
   position: absolute;
   top: -0.4em;
   left: calc(100% + 1em);
-  font-size: 11px;
+  font-size: 12px;
   color: #aaa;
   z-index: 2;
 }

--- a/src/js/cash-bail-and-race.js
+++ b/src/js/cash-bail-and-race.js
@@ -190,7 +190,7 @@ const createRaceScatterPlot = () => {
     columns: [
       { dataKey: "name", isRowHeader: true },
       { columnHeader: "% Cash Bail", dataKey: "x", render: value => `${value.toFixed(1)}%` },
-      { columnHeader: "Avg. Bail Amount", dataKey: "y", render: value => value.toLocaleString("en", {
+      { columnHeader: "Bail Amount", dataKey: "y", render: value => value.toLocaleString("en", {
         style: "currency",
         currency: "USD",
         minimumFractionDigits: 0,


### PR DESCRIPTION
Fixes the following:
- On plot-container, remove 50px margin at the bottom
- Axes labels missing (higher cash bail rate, lower cash bail amt, higher cash bail amt)
- Tooltip: change ‘avg. bail amount’ to bail amount (AND desktop)
- Chart grid is just a little hard to see.  → change scatterplot background fill to 7.5% opacity
- Anything font size that is 11px or lower on desktop, make 12px – but keep the font sizes as is on mobile
- I can’t see the first few letters I type into the search bar
- Leave no gaps between table options
- There’s a double stroke happening between the switches
- Capitalize all toggle text
- Change ‘Average Bail Set’ to ‘Bail Set’ and get ’Bail Set’ on one line