### PR TITLE
Implement Map Improvements

### DIFF
--- a/src/css/map.css
+++ b/src/css/map.css
@@ -19,7 +19,7 @@
 }
 
 .county-path {
-  stroke: #c6c6c6;
+  stroke: #000;
 }
 
 .legend-container {

--- a/src/js/classes/Map.js
+++ b/src/js/classes/Map.js
@@ -266,6 +266,7 @@ class Map {
 
   onMouseEnter(event) {
     this.showTooltip(event.target, {});
+    this.highlightMapForCounty(event.target)
   }
 
   onMouseOut() {
@@ -282,6 +283,12 @@ class Map {
       this.tooltip.hide();
       this.tooltip.destroy();
     }
+  }
+
+  highlightMapForCounty(element) {
+    this.svg
+    .selectAll(`path:not([${COUNTY_NAME_ATTRIBUTE}="${element.getAttribute(COUNTY_NAME_ATTRIBUTE)}"])`)
+    .style("opacity", "0.2")
   }
 
   render() {
@@ -326,7 +333,7 @@ export class BailRateMap extends Map {
 
     const onLegendMouseOver = (event) => {
       this.highlightBar(event.target);
-      this.highlightMap(event.target);
+      this.highlightMapForBucket(event.target);
     };
     const onLegendMouseOut = () => this.resetHighlight();
     onLegendMouseOver.bind(this);
@@ -373,7 +380,7 @@ export class BailRateMap extends Map {
     this.legend.highlightBars([bucket]);
   }
 
-  highlightMap(element) {
+  highlightMapForBucket(element) {
     const bucket = element.getAttribute(BUCKET_ATTRIBUTE);
     this.svg
       .selectAll(`path:not([${BUCKET_ATTRIBUTE}="${bucket}"])`)
@@ -441,6 +448,7 @@ class BailRaceMap extends Map {
       .selectAll(`path[${COUNTY_NAME_ATTRIBUTE}="${countyName}"]`)
       .style("stroke-width", "2px");
     super.showTooltip(element, tooltipData);
+    this.highlightMapForCounty(element);
   }
   _onMouseOut(countyName) {
     super.onMouseOut();
@@ -449,7 +457,7 @@ class BailRaceMap extends Map {
       .style("stroke-width", "1px");
   }
 
-  highlightMap(bucket) {
+  highlightMapForBucket(bucket) {
     this.svg
       .selectAll(`path:not([${BUCKET_ATTRIBUTE}="${bucket}"])`)
       .style("opacity", "0.2");
@@ -526,7 +534,7 @@ export class RaceMapContainer {
 
     const onLegendMouseOver = (event) => {
       this.highlightBarFromLegend(event.target);
-      this.highlightMap(event.target);
+      this.highlightMapForBucket(event.target);
     };
     const onLegendMouseOut = () => this.resetHighlight();
     onLegendMouseOver.bind(this);
@@ -594,10 +602,10 @@ export class RaceMapContainer {
     this.legend.highlightBars(buckets);
   }
 
-  highlightMap(element) {
+  highlightMapForBucket(element) {
     const bucket = element.getAttribute(BUCKET_ATTRIBUTE);
-    this.black.highlightMap(bucket);
-    this.white.highlightMap(bucket);
+    this.black.highlightMapForBucket(bucket);
+    this.white.highlightMapForBucket(bucket);
   }
 
   resetHighlight() {
@@ -647,7 +655,7 @@ export class BailPostingMap extends Map {
 
     const onLegendMouseOver = (event) => {
       this.highlightBar(event.target);
-      this.highlightMap(event.target);
+      this.highlightMapForBucket(event.target);
     };
     const onLegendMouseOut = () => this.resetHighlight();
     onLegendMouseOver.bind(this);
@@ -716,7 +724,7 @@ export class BailPostingMap extends Map {
     this.legend.highlightBars([bucket]);
   }
 
-  highlightMap(element) {
+  highlightMapForBucket(element) {
     const bucket = element.getAttribute(BUCKET_ATTRIBUTE);
     this.svg.selectAll("path").style("opacity", "0.2");
     this.svg

--- a/src/js/classes/Map.js
+++ b/src/js/classes/Map.js
@@ -167,9 +167,10 @@ class SpikeLegend {
     this.values = values;
     this.getSpike = getSpike;
 
-    this.spikeOffsetY = 110;
+    this.spikeOffsetY = 115;
     this.spikeOffsetX = 40;
     this.spikeSpacingX = 30;
+    this.spikeLabelOffsetY = 20;
 
     const svgWidth = 140;
     const svgHeight = this.spikeOffsetY + 25;
@@ -202,7 +203,7 @@ class SpikeLegend {
       .data(this.values)
       .join("text")
       .attr("x", (_, i) => i * this.spikeSpacingX + this.spikeOffsetX / 2)
-      .attr("y", (_, i) => (this.values.length - i - 1) * 30 + 15)
+      .attr("y", (_, i) => (this.values.length - i - 1) * 30 + this.spikeLabelOffsetY)
       .attr("class", "legend-text")
       .text((d) => d);
     // Add title


### PR DESCRIPTION
- Change Choloropleth county outlines to black
- County hover reduces opacity of non-hovered counties
- Aligns spike label with color legend for Bail Posting Map