### PR TITLE
Remove duplicate labels and center axis label

### DIFF
--- a/src/css/graph.css
+++ b/src/css/graph.css
@@ -242,7 +242,7 @@ svg.label-wrapper {
 }
 
 /* these are custom breakpoints to make the svg work well on phones */
-@media only screen and (max-width: 670px) {
+@media only screen and (max-width: 680px) {
   .scatter-plot {
     width: 300px;
     height: 400px;

--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -82,7 +82,7 @@
 }
 
 /* these are custom breakpoints to make the svg work well on phones */
-@media only screen and (max-width: 670px) {
+@media only screen and (max-width: 680px) {
   .tippy-popper {
     position: fixed !important;
     transform: none !important;

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -244,13 +244,14 @@ export class ScatterPlot {
     this.sizing = getSizing(window.innerWidth);
 
     // set viewbox based on window size (customized for specific phones)
-    const width = this.sizing === SMALL_PHONE
-      ? 180
-      : this.sizing === LARGE_PHONE
-      ? 280
-      : this.sizing === SMALL_BROWSER
-      ? 300
-      : 600;
+    const width =
+      this.sizing === SMALL_PHONE
+        ? 180
+        : this.sizing === LARGE_PHONE
+        ? 280
+        : this.sizing === SMALL_BROWSER
+        ? 300
+        : 600;
     const height = this.sizing === REGULAR_WIDTH ? 500 : 400;
     this.plot.setAttributeNS(null, "viewBox", `0 0 ${width} ${height}`);
     if (prevSizing !== this.sizing) {
@@ -266,7 +267,9 @@ export class ScatterPlot {
           circles[i].setAttributeNS(
             null,
             "r",
-            this.sizing === REGULAR_WIDTH ? point.rsDesktop[i] : point.rsMobile[i]
+            this.sizing === REGULAR_WIDTH
+              ? point.rsDesktop[i]
+              : point.rsMobile[i]
           );
         });
       });
@@ -345,17 +348,8 @@ export class ScatterPlot {
     // wrap axis labels in svgs to do local rotation
     const wrapper = document.createElementNS(SVG_NS, "svg");
     wrapper.setAttributeNS(null, "class", "label-wrapper");
-    if (this.sizing === REGULAR_WIDTH) {
-      wrapper.setAttributeNS(null, "x", isLower ? 0 : isYAxis ? 0 : "100%");
-      wrapper.setAttributeNS(
-        null,
-        "y",
-        isLower ? "100%" : isYAxis ? 0 : "100%"
-      );
-    } else {
-      wrapper.setAttributeNS(null, "x", isYAxis ? 0 : "50%");
-      wrapper.setAttributeNS(null, "y", isYAxis ? "50%" : "100%");
-    }
+    wrapper.setAttributeNS(null, "x", isYAxis ? 0 : "50%");
+    wrapper.setAttributeNS(null, "y", isYAxis ? "50%" : "100%");
 
     // get offset based on window size
     const dy = this.sizing === REGULAR_WIDTH ? 60 : 40;
@@ -401,9 +395,13 @@ class DistributionRow {
     return this.renderTooltip(
       elements,
       [
-        this.distributions.reduce((acc, dist) => ({
-          ...acc, [dist["className"]]: dist["value"]
-        }), {})
+        this.distributions.reduce(
+          (acc, dist) => ({
+            ...acc,
+            [dist["className"]]: dist["value"]
+          }),
+          {}
+        )
       ],
       this.county
     );
@@ -469,7 +467,7 @@ export class DistributionGraph {
       container.appendChild(colorBox);
       container.appendChild(text);
       return container;
-    }
+    };
 
     // configureTooltip returns a render function to which we'll pass the data
     return configureTooltip({
@@ -501,9 +499,8 @@ export class DistributionGraph {
 class Row {
   constructor(data, minValue, maxValue, renderTooltip) {
     this.data = data;
-    this.renderTooltip = (elements) => renderTooltip(
-      elements, [data], this.data.name
-    );
+    this.renderTooltip = (elements) =>
+      renderTooltip(elements, [data], this.data.name);
     this.barWidth = ((data.x - minValue) * 100) / (maxValue - minValue);
   }
 


### PR DESCRIPTION

<img width="722" alt="Screen Shot 2022-07-31 at 5 38 33 PM" src="https://user-images.githubusercontent.com/13203039/182046376-56799fb8-47d3-4466-85de-dbff5f941776.png">
<img width="729" alt="Screen Shot 2022-07-31 at 5 38 46 PM" src="https://user-images.githubusercontent.com/13203039/182046377-019daeb8-b938-4634-8f2e-a949752167e8.png">

- Removed code that duplicated axis labels
- Noticed that we were using inconsistent widths for small window sizes (sometimes 670px and sometimes 680px). This PR updates them all to be 680px