### PR TITLE
Style nits, mobile sizing fixes, and map data fixes

### DIFF
--- a/bail-trends.html
+++ b/bail-trends.html
@@ -158,7 +158,7 @@
       </div>
       <div class="graph">
         <h3 class="title">Rates of Each Bail Type by County</h3>
-        <div id="dist-graph-legend">
+        <div class="dist-graph-legend">
           <div class="legend-segment cash-bail-legend">
             <div class="legend-color-bar cash-bar"></div>
             <div class="legend-header">Cash Bail</div>

--- a/cash-bail-and-race.html
+++ b/cash-bail-and-race.html
@@ -33,7 +33,7 @@
         <div id="black" class="map race-map choropleth"></div>
         <div id="white" class="map race-map choropleth"></div>
       </div>
-      <p class="footnote">
+      <p class="footnote map-footnote">
         Note: Counties that had fewer than 50 cases involving a Black
         defendant are specially marked to flag the small number of cases.
         Numbers for these counties may not be meaningful. Further, AOPC data

--- a/mdjs.html
+++ b/mdjs.html
@@ -24,7 +24,7 @@
     <div class="container">
       <div class="table-container" id="mdj-container">
         <h3 class="title">Rates of Each Bail Type by Magisterial District Court</h3>
-        <div id="dist-graph-legend">
+        <div class="dist-graph-legend mdjs-legend">
           <div class="legend-segment cash-bail-legend">
             <div class="legend-color-bar cash-bar"></div>
             <div class="legend-header">Cash Bail</div>

--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -3,34 +3,18 @@
     max-width: 100%;
   }
 
-  .table-container > table th {
-    padding: 1em 0.5em;
-  }
-
-  .table-container > table td {
-    padding: 1em 0.5em;
-  }
-
   .table-container > table th.viz-cell {
     width: 100px;
-    margin: 0 1em;
   }
 
   .table-container > table td.viz-cell {
     width: 100px;
-    margin: 0 1em;
-    padding: 1.5em 0;
     border-left: 1px dotted #333;
     border-right: 1px dotted #333;
   }
 
   .average-wrapper {
     width: 100px;
-  }
-
-  .table-container > table .county-name-cell {
-    min-width: 75px;
-    max-width: 75px;
   }
 
   .table-container > table .number-cell {
@@ -70,11 +54,6 @@
 
   .bar-label {
     left: calc(100% + 0.5em);
-    font-size: 11px;
-  }
-
-  .viz-bar {
-    height: 1em;
   }
 
   .switch-container {
@@ -121,7 +100,18 @@
   }
 }
 
+@media only screen and (max-width: 600px) {
+  #avg-bail-graph-container {
+    margin-right: 1.2em;
+  }
+}
+
 @media only screen and (max-width: 425px) {
+  .table-container > table .county-name-cell {
+    min-width: 75px;
+    max-width: 100px;
+  }
+
   .table-container > table th.viz-cell {
     width: 80px;
   }
@@ -167,11 +157,34 @@
 
 @media only screen and (max-width: 350px) {
   .table-container > table td.viz-cell,
-  table th.viz-cell {
+  table th.viz-cell,
+  .mdjs-legend {
     display: none;
   }
 
   .legend-segment {
-    padding: 0 2px;
+    padding: 0 1px;
+  }
+
+  .legend-color-bar {
+    width: 61px;
+  }
+
+  .legend-header {
+    font-size: 10px;
+  }
+
+  .viz-county-name-column {
+    width: 90px;
+  }
+
+  .viz-plot-column {
+    inset: 0 0 0 90px;
+  }
+
+  #dist-graph-container,
+  #avg-bail-graph-container {
+    margin-right: 1em;
+    font-size: 11px;
   }
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -28,7 +28,7 @@ h3.title {
   margin-bottom: 20px;
   text-align: center;
   font-family: "GT America Bold";
-  font-size: 14px;
+  font-size: 18px;
   line-height: 28px;
 }
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -43,7 +43,7 @@ h3.title {
 
 .footnote {
   max-width: 600px;
-  margin: 10px auto;
+  margin: 40px auto;
   color: rgba(255, 255, 255, 0.75);
   font-family: "GT America";
   font-size: 12px;
@@ -51,7 +51,11 @@ h3.title {
 }
 
 .footnote.graph-footnote {
-  margin-top: 70px;
+  margin-top: 100px;
+}
+
+.footnote.map-footnote {
+  margin-top: 0;
 }
 
 .mobile-only {

--- a/src/css/table.css
+++ b/src/css/table.css
@@ -27,28 +27,18 @@
 }
 
 .table-container > table th {
-  padding: 13px 6px;
+  padding: 1em 0.4em;
   color: #fff;
   font-family: "GT America Condensed";
   font-weight: 400;
-  font-size: 12px;
   text-align: left;
   text-transform: uppercase;
   vertical-align: bottom;
 }
 
-.table-container > table th.number-cell {
-  text-align: right;
-  box-sizing: content-box;
-}
-
-.table-container > table th.retention-fee-cell {
-  text-align: left;
-}
-
 .table-container > table td {
   text-align: left;
-  padding: 8px 6px;
+  padding: 0.8em 0.4em;
 }
 
 .table-container > table .number-cell {
@@ -56,11 +46,18 @@
   min-width: 60px;
   max-width: 80px;
   text-align: right;
+}
+
+.table-container > table th.number-cell {
+  box-sizing: content-box;
+}
+
+.table-container > table td.number-cell {
   font-variant-numeric: tabular-nums;
 }
 
 .table-container > table .county-name-cell {
-  min-width: 170px;
+  min-width: 120px;
   color: rgba(255, 255, 255, 1);
 }
 

--- a/src/css/visualization.css
+++ b/src/css/visualization.css
@@ -39,7 +39,7 @@
 
 .viz-line {
   position: absolute;
-  top: 16px;
+  top: 18px;
   bottom: -8px;
   width: 1px;
   background: #333;

--- a/src/css/visualization.css
+++ b/src/css/visualization.css
@@ -1,15 +1,13 @@
 .table-container > table th.viz-cell {
   width: 120px;
-  padding: 13px 0;
+  padding: 1em 0;
   font-family: "GT America Condensed";
-  line-height: 13px;
 }
 
 .table-container > table th.bail-dist-cell {
-  padding-left: 26px;
+  padding-left: 2em;
   font-family: "GT America Condensed";
   font-weight: 400;
-  font-size: 12px;
   text-align: left;
 }
 
@@ -118,15 +116,14 @@
   position: absolute;
   top: -0.4em;
   left: calc(100% + 1em);
-  font-size: 12px;
   color: #aaa;
-  z-index: 2;
+  z-index: 3;
 }
 
 .bar-average-line {
   position: absolute;
   height: 100%;
-  margin: -2em 0;
+  margin: -1.7em 0;
 }
 
 .bar-average-line.green {
@@ -147,10 +144,11 @@
 
 .viz-number-line-point {
   position: absolute;
-  top: 1.25em;
-  width: 6px;
-  height: 6px;
+  top: 1.2em;
+  width: 0.5em;
+  height: 0.5em;
   border-radius: 50%;
+  z-index: 2;
 }
 
 .viz-number-line-point.green {
@@ -159,6 +157,18 @@
 
 .viz-number-line-point.purple {
   background-color: #c14ef8;
+}
+
+/* General viz stuff; shared for easy mobile resizing! */
+
+.viz-county-name-column {
+  width: 110px;
+  line-height: 1;
+}
+
+.viz-plot-column {
+  position: absolute;
+  inset: 0 0 0 110px;
 }
 
 /* Bail Distribution Visualization */
@@ -210,8 +220,6 @@
 }
 
 .dist-county-name {
-  width: 120px;
-  line-height: 1;
   margin-bottom: 6px;
 }
 
@@ -285,7 +293,7 @@
   height: 19px;
 }
 
-#dist-graph-legend {
+.dist-graph-legend {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -295,8 +303,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0 10px;
-  margin: 25px 0 50px;
+  padding: 0 1em;
+  margin: 2em 0 3em;
 }
 
 .legend-color-bar {
@@ -307,13 +315,12 @@
 
 .legend-header {
   color: rgba(255, 255, 255, 0.75);
-  margin-top: 15px;
+  margin-top: 1em;
 }
 
 /* Avg Bail Amount Visualization */
 #avg-bail-graph-container {
   position: relative;
-  width: 100%;
 }
 
 #avg-bail-graph-container .bar-chart-plot {
@@ -321,8 +328,6 @@
 }
 
 #avg-bail-graph-container .bar-chart-plotlines {
-  position: absolute;
-  inset: 0 0 0 120px;
   display: flex;
   border-left: 1px dashed rgba(255, 255, 255, 0.3);
   pointer-events: none;
@@ -344,6 +349,7 @@
   flex: 1;
   width: 0;
 }
+
 #avg-bail-graph-container .bar-chart-xaxis .tick > p {
   width: fit-content;
   transform: translateX(-50%);
@@ -352,9 +358,6 @@
 
 #avg-bail-graph-container .bar-chart-xaxis .tick:last-of-type {
   flex: 0;
-}
-#avg-bail-graph-container .bar-chart-xaxis .bar-chart-sort-button {
-  width: 120px;
 }
 
 #avg-bail-graph-container .bar-chart-xaxis .bar-chart-sort-button > button {
@@ -376,11 +379,6 @@
 /* Allow specific row to remain highlighted on hover */
 #avg-bail-graph-container .bar-chart-row:hover .county-name {
   color: rgba(238, 238, 238, 1);
-}
-
-#avg-bail-graph-container .county-name {
-  line-height: 1;
-  width: 120px;
 }
 
 #avg-bail-graph-container .bar-chart-row:not(:last-child) .county-name {

--- a/src/js/bail-trends.js
+++ b/src/js/bail-trends.js
@@ -12,7 +12,8 @@ import {
   BAIL_RATE_DATA,
   ROR_RATE_DATA,
   BAIL_POSTING_DATA,
-  COUNTY_BAIL_TYPE_DATA
+  COUNTY_BAIL_TYPE_DATA,
+  BAIL_RATE_MAP_DATA
 } from "./data";
 
 /* TABLE CREATION FUNCTIONS */
@@ -380,13 +381,15 @@ createBailPostingTable();
 /* RENDER MAPS */
 const cashBailRateMap = new BailRateMap(
   "cash-bail-rate",
-  BAIL_RATE_DATA,
+  BAIL_RATE_MAP_DATA,
+  "cashBailRate",
   STATE_DATA["cash_bail_pct"],
   "Cash Bail Rate"
 );
 const rorRateMap = new BailRateMap(
   "ror-rate",
-  ROR_RATE_DATA,
+  BAIL_RATE_MAP_DATA,
+  "rorRate",
   STATE_DATA["ror_pct"],
   "ROR Rate"
 );

--- a/src/js/cash-bail-and-race.js
+++ b/src/js/cash-bail-and-race.js
@@ -3,7 +3,11 @@ import { Table, SwitchableTable } from "./classes/Table.js";
 import { RaceMapContainer } from "./classes/Map.js";
 import { ScatterPlot } from "./classes/Graph.js";
 import { STATE_DATA, COUNTY_DATA } from "./raw-data.js";
-import { BAIL_RACE_RATE_DATA, BAIL_RACE_AMOUNT_DATA } from "./data.js";
+import {
+  BAIL_RACE_RATE_DATA,
+  BAIL_RACE_AMOUNT_DATA,
+  BAIL_RATE_MAP_DATA
+} from "./data.js";
 
 /* TABLE CREATION FUNCTIONS */
 const createBailRaceRateTable = () => {
@@ -306,9 +310,11 @@ new SwitchableTable(bailRaceRateTable, bailRaceAmountTable, raceContainer);
 /* RENDER MAPS */
 new RaceMapContainer(
   "race-rate",
-  BAIL_RACE_RATE_DATA,
-  STATE_DATA["cash_bail_pct_black"],
-  STATE_DATA["cash_bail_pct_white"]
+  BAIL_RATE_MAP_DATA,
+  {
+    black: STATE_DATA["cash_bail_pct_black"],
+    white: STATE_DATA["cash_bail_pct_white"]
+  }
 );
 
 /* RENDER GRAPHS */

--- a/src/js/classes/Graph.js
+++ b/src/js/classes/Graph.js
@@ -410,7 +410,7 @@ class DistributionRow {
   render() {
     // Add county name
     const nameElement = document.createElement("div");
-    nameElement.className = "dist-county-name";
+    nameElement.className = "dist-county-name viz-county-name-column";
     nameElement.innerText = this.county;
     // Add distribution bars
     const distBarsSegment = document.createElement("div");
@@ -507,7 +507,7 @@ class Row {
   render() {
     // Add county name
     const nameElement = document.createElement("div");
-    nameElement.className = "county-name";
+    nameElement.className = "county-name viz-county-name-column";
     nameElement.innerText = this.data.name;
 
     // Add bar
@@ -573,7 +573,7 @@ export class CountyBarChart {
 
   renderPlotLines(xAxis) {
     const plotLines = document.createElement("div");
-    plotLines.className = "bar-chart-plotlines";
+    plotLines.className = "bar-chart-plotlines viz-plot-column";
     for (let i = 0; i < xAxis.numTicks; i++) {
       const plotLine = document.createElement("div");
       plotLine.className = "bar-chart-plotline";
@@ -588,7 +588,7 @@ export class CountyBarChart {
     axis.className = "bar-chart-xaxis";
 
     const sortButtonWrapper = document.createElement("div");
-    sortButtonWrapper.className = "bar-chart-sort-button";
+    sortButtonWrapper.className = "bar-chart-sort-button viz-county-name-column";
     const sortButton = document.createElement("button");
     sortButton.innerHTML = "SORT";
     const label = document.createElement("h4");

--- a/src/js/classes/Table.js
+++ b/src/js/classes/Table.js
@@ -6,7 +6,6 @@ import {
   NUM_TRUNCATED_ROWS,
   CARET_SVG,
   ARROW_SVG,
-  SMALL_BROWSER,
   SMALL_PHONE
 } from "../constants";
 

--- a/src/js/classes/Table.js
+++ b/src/js/classes/Table.js
@@ -369,7 +369,7 @@ class VizHeaderCell extends HeaderCell {
   }
 
   getEndNumMargin() {
-    return this.sizing === SMALL_PHONE || this.sizing === SMALL_BROWSER ? "0" : "-13px";
+    return this.sizing === SMALL_PHONE ? "0" : "-13px";
   }
 }
 

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -23,3 +23,12 @@ export const REGULAR_WIDTH = "REGULAR_WIDTH";
 export const SMALL_BROWSER = "SMALL_BROWSER";
 export const LARGE_PHONE = "LARGE_PHONE";
 export const SMALL_PHONE = "SMALL_PHONE";
+
+export const BAIL_RATE_MAP_COLOR_CONFIG = {
+  domain: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+  colors: ["#182935", "#215f5d", "#1b9b88", "#0fc59b", "#0fda92", "#00ed89"]
+};
+export const BAIL_RATE_RACE_MAP_COLOR_CONFIG = {
+  domain: [0.2, 0.4, 0.6, 0.8, 1],
+  colors: ["#CC2FFF", "#B08CF0", "#7AC7DF", "#5DDAB5", "#00ED89"]
+};

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -72,6 +72,15 @@ export const COUNTY_BAIL_TYPE_DATA = COUNTY_DATA.map((countyData) => ({
   ],
 }));
 
+export const BAIL_RATE_MAP_DATA = COUNTY_DATA.map((countyData) => ({
+  name: countyData["name"],
+  rorRate: countyData["ror_pct"],
+  cashBailRate: countyData["cash_bail_pct"],
+  cashBailRateBlack: countyData["cash_bail_pct_black"],
+  cashBailRateWhite: countyData["cash_bail_pct_white"],
+  outlier: countyData["is_outlier"]
+}));
+
 export const BAIL_RACE_RATE_DATA = COUNTY_DATA.map((countyData) => ({
   data: [
     countyData["name"],


### PR DESCRIPTION
## Changes
- Fix bail race map data issues
  - The map classes expected the data to be in a certain order in an array; since we were reusing the same arrays from the tables, when I changed those to include cash bail cases it changed the order
  - To better future-proof this I changed the `BailRateMap` and `BailRaceMap` implementations to take an object and the key to select, which also allows us to use the same map data object `BAIL_RATE_MAP_DATA` for all maps
  - I also did this for the averages as they were in the wrong order

|Old|New|
|---|---|
|<img width="414" alt="bail-race-legend-old" src="https://user-images.githubusercontent.com/16271232/182983648-eb402fbc-5a60-4dd4-82bd-cd9799a7ed90.png">|<img width="499" alt="bail-race-legend-new" src="https://user-images.githubusercontent.com/16271232/182983658-1b6173b8-ba99-4496-8300-01349acd7b69.png">|

- Increase title font size to 18px
- Increase table header font size to 13px
- Switch visualizations in tables to use em rather than px
  - This made it easier to fix the alignment of the dots
  - Other small style fixes in the viz: align dotted average lines properly with the top and bottom of the table; move dots to in front of the average lines; and align headers properly

|Old|New|
|---|---|
|<img width="804" alt="table-viz-old" src="https://user-images.githubusercontent.com/16271232/182983785-22003069-b83a-44f8-9494-7102c9f1dc11.png">|<img width="795" alt="table-viz-new" src="https://user-images.githubusercontent.com/16271232/182983792-5c119439-050b-47c3-8dbb-e737badb5343.png">|

- Mobile sizing fix: make county name columns narrower on mobile to avoid overflow/horizontal scrolling
- Mobile sizing fix: prevent horizontal scrolling and overlap on very small phones for average bail amount/non-posting rate chart; note that this looks a little different in dev vs. on the staging site because of the additional containers and whatnot but it should still work because the fix for the horizontal scrolling was to add a small margin to the right side of the graph on mobile

|Old|New|
|---|---|
|<img width="320" alt="average-bail-amount-mobile-old" src="https://user-images.githubusercontent.com/16271232/182984448-33e038f0-d54b-4242-a574-a230a8bea8bd.png">|<img width="321" alt="average-bail-amount-mobile-new" src="https://user-images.githubusercontent.com/16271232/182984461-e0964f28-4271-4aa0-88d1-2c724c306fa5.png">|

- Mobile sizing fix: make sure the bail type chart legend fits without overflow on small phones (note both this and the above change requiring reducing the text size to 11px, which is something we're doing elsewhere on the site)

|Old|New|
|---|---|
|<img width="321" alt="bail-type-old" src="https://user-images.githubusercontent.com/16271232/182984828-5ca0b8bc-29af-4836-bd94-fa7ac1a6a5af.png">|<img width="317" alt="bail-type-new" src="https://user-images.githubusercontent.com/16271232/182984832-26400f9f-795c-40ee-aa8f-3b54e596abe7.png">|